### PR TITLE
bug: git PDFs were missing CSS styling file

### DIFF
--- a/dockerfiles/steps/git-link-rex.bash
+++ b/dockerfiles/steps/git-link-rex.bash
@@ -11,3 +11,4 @@ book_slugs_file="/tmp/book-slugs.json"
 try cat $abl_file | jq ".approved_books|map(.books)|flatten" > "$book_slugs_file"
 
 try link-rex "$IO_MATHIFIED/$ARG_TARGET_SLUG_NAME.mathified.xhtml" "$book_slugs_file" "$target_dir" "$filename"
+try cp "$IO_MATHIFIED/the-style-pdf.css" "$IO_REX_LINKED"

--- a/dockerfiles/steps/git-pdfify.bash
+++ b/dockerfiles/steps/git-pdfify.bash
@@ -1,3 +1,14 @@
 parse_book_dir
 
 try prince -v --output="$IO_ARTIFACTS/$ARG_TARGET_PDF_FILENAME" "$IO_REX_LINKED/$ARG_TARGET_SLUG_NAME.rex-linked.xhtml"
+
+# Verify the style file exists before building a PDF
+# LCOV_EXCL_START
+if [[ ! -f "$IO_REX_LINKED/the-style-pdf.css" ]]; then
+    say "=============================================="
+    say " WARNING: There was no CSS file. Maybe a bug?"
+    say " WARNING: Waiting 15 seconds"
+    say "=============================================="
+    try sleep 15
+fi
+# LCOV_EXCL_STOP


### PR DESCRIPTION
When the rex-link step was added the CSS file was not copied over from the mathify step.

Alternatively, we could only copy the CSS file from the baking step into the PDF step but then opening the HTML in a browser for debugging would not contain the CSS.