### PR TITLE
Update test-step-09: warn when shellcheck absent

### DIFF
--- a/test/test-step-09.bash
+++ b/test/test-step-09.bash
@@ -6,4 +6,6 @@ set -e
 # Lint the bash scripts
 if [[ $(command -v shellcheck) ]]; then
     shellcheck --severity=warning ../dockerfiles/steps/* ../dockerfiles/build/*
+else
+    echo "Warning: Linting failed, shellcheck not found"
 fi


### PR DESCRIPTION
Just a small addition to warn you if you are running tests locally and shellcheck is not installed. It can be frustrating to discover liniting problems after creating a pull request. 