### PR TITLE
Update prince

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN curl -o /tmp/AdobeICCProfiles.zip https://download.adobe.com/pub/adobe/iccpr
 # Install princexml
 # ---------------------------
 
-ENV PRINCE_VERSION=12.5.1-1
+ENV PRINCE_VERSION=14.2-1
 ENV PRINCE_UBUNTU_BUILD=20.04
 
 RUN wget --directory-prefix=/tmp/ https://www.princexml.com/download/prince_${PRINCE_VERSION}_ubuntu${PRINCE_UBUNTU_BUILD}_amd64.deb

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -50,7 +50,7 @@ RUN curl -o /tmp/AdobeICCProfiles.zip https://download.adobe.com/pub/adobe/iccpr
 # Install princexml
 # ---------------------------
 
-ENV PRINCE_VERSION=12.5.1-1
+ENV PRINCE_VERSION=14.2-1
 ENV PRINCE_UBUNTU_BUILD=20.04
 
 RUN wget --directory-prefix=/tmp/ https://www.princexml.com/download/prince_${PRINCE_VERSION}_ubuntu${PRINCE_UBUNTU_BUILD}_amd64.deb


### PR DESCRIPTION
Update Prince to version 14.2-1 for Ubuntu 20.04. Prince version has been updated manually in the `Dockerfile.commom` file has been generated by using `./build-dockerfile.sh`.
For: https://github.com/openstax/cnx-recipes/issues/4208
Within investigating issue containing collected information and related opened issues: https://github.com/openstax/cnx-recipes/issues/4353