### PR TITLE
switch sandbox back to using the main ABL branch

### DIFF
--- a/build-concourse/env/webhosting-sandbox.json
+++ b/build-concourse/env/webhosting-sandbox.json
@@ -3,7 +3,7 @@
     "MAX_INFLIGHT_JOBS": 5,
     "AWS_SECRET_ACCESS_KEY": "((aws-sandbox-secret-access-key))",
     "AWS_ACCESS_KEY_ID": "((aws-sandbox-secret-key-id))",
-    "ABL_FILE_URL": "https://raw.githubusercontent.com/openstax/content-manager-approved-books/staging/approved-book-list.json",
+    "ABL_FILE_URL": "https://raw.githubusercontent.com/openstax/content-manager-approved-books/main/approved-book-list.json",
     "CORGI_ARTIFACTS_S3_BUCKET": "openstax-sandbox-web-hosting-content-gatekeeper",
     "WEB_S3_BUCKET": "openstax-sandbox-web-hosting-content-gatekeeper",
     "WEB_QUEUE_STATE_S3_BUCKET": "openstax-sandbox-web-hosting-content-queue-state",


### PR DESCRIPTION
We can switch it to another branch name in the future if we need to test ABL-specific changes (like a schema upgrade)