### PR TITLE
Change ABL_FILE_URL in cli.env to specific commit

### DIFF
--- a/cli.env
+++ b/cli.env
@@ -5,7 +5,7 @@ ARG_S3_BUCKET_NAME=openstax-sandbox-cops-artifacts
 LOCAL_ATTIC_DIR=_attic
 INPUT_SOURCE_DIR=_book-input
 
-ABL_FILE_URL=https://raw.githubusercontent.com/openstax/content-manager-approved-books/main/approved-book-list.json
+ABL_FILE_URL=https://raw.githubusercontent.com/openstax/content-manager-approved-books/adfb6cea998084a8de6d76f768b41f496462d8e8/approved-book-list.json
 
 IO_BOOK=/data/book
 IO_ARCHIVE_FETCHED=/data/archive-fetched


### PR DESCRIPTION
refs [1830](https://app.zenhub.com/workspaces/content-engineering-tech-team-5af1f4cc12da5e6d74331b60/issues/openstax/ce/1830)

Updating the `ABL_FILE_URL` in cli.env should not impact CORGI or Webhosting since they have their own definition for that variable that is inserted into the YAML files when you run their build scripts. It should only impact the cli. Granted, we should probably remove archive tests entirely at some point.

This change does have larger implications in that the static commit will be used for any archive jobs executed on the command line. Archive jobs through CORGI, however, will still use the main branch of the ABL. If this becomes a problem for local development, the environment variable can be updated locally.