### PR TITLE
1914 gdocify multitasking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install pipenv & Setting up environment
         run: |
           python -m pip install --upgrade pipenv wheel

--- a/bakery-src/scripts/gdocify_book.py
+++ b/bakery-src/scripts/gdocify_book.py
@@ -2,7 +2,7 @@
 """
 import json
 import re
-import subprocess
+import asyncio
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -102,26 +102,112 @@ def _convert_cmyk2rgb_embedded_profile(img_filename):
     """ImageMagick commandline to convert from CMYK with
     an existing embedded icc profile"""
     # mogrify -profile sRGB.icc +profile '*' picture.jpg
-    return ['mogrify', '-profile', SRGB_ICC, '+profile', "'*'", str(img_filename)]  # pragma: no cover
+    return f'mogrify -profile "{SRGB_ICC}" +profile \'*\' "{img_filename}"'  # pragma: no cover
 
 
 def _convert_cmyk2rgb_no_profile(img_filename):
     """ImageMagick commandline to convert from CMYK without any
     embedded icc profile"""
     # mogrify -profile USWebCoatedSWOP.icc -profile sRGB.icc +profile '*' picture.jpg
-    return ['mogrify', '-profile', USWEBCOATEDSWOP_ICC, '-profile', SRGB_ICC,
-            '+profile', "'*'", str(img_filename)]  # pragma: no cover
+    return (f'mogrify -profile "{USWEBCOATEDSWOP_ICC}" -profile "{SRGB_ICC}"'
+            f' +profile \'*\' "{img_filename}"')  # pragma: no cover
 
 
 def _universal_convert_rgb_command(img_filename):
     """ImageMagick commandline to convert an unknown color profile to RGB.
     Warning: Probably does not work perfectly color accurate."""
-    return ['mogrify', '-colorspace', 'sRGB', '-type', 'truecolor', str(img_filename)]  # pragma: no cover
+    return f'mogrify -colorspace sRGB -type truecolor "{img_filename}"'  # pragma: no cover
 
 
-def fix_jpeg_colorspace(doc, out_dir):
+async def fix_jpeg_colorspace(img_filename):
     """Searches for JPEG image resources which are encoded in colorspace
     other than RGB or Greyscale and convert them to RGB"""
+    if img_filename.is_file():
+        mime_type = utils.get_mime_type(str(img_filename))
+
+        # Only check colorspace of JPEGs (GIF, PNG etc. don't have breaking colorspaces)
+        if mime_type == 'image/jpeg':
+            try:
+                im = Image.open(str(img_filename))
+                # https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
+                colorspace = im.mode
+                im.close()
+                if not re.match(r"^RGB.*", colorspace):  # pragma: no cover
+                    if colorspace != '1' and not re.match(r"^L\w?", colorspace):
+                        # here we have a color space like CMYK or YCbCr most likely
+                        # decide which command line to use
+                        if colorspace == 'CMYK':
+                            with TemporaryDirectory() as temp_dir:
+                                profile = Path(temp_dir) / Path('embedded.icc')
+                                # save embedded profile if existing
+                                extractembedded = await asyncio.create_subprocess_shell(
+                                    f'convert "{img_filename}" "{profile}"',
+                                    stdout=asyncio.subprocess.PIPE,
+                                    stderr=asyncio.subprocess.PIPE)
+                                stdout, stderr = await extractembedded.communicate()
+                                # was there an embedded icc profile?
+                                if extractembedded.returncode == 0 and \
+                                        profile.is_file() and \
+                                        profile.stat().st_size > 0:
+                                    cmd = _convert_cmyk2rgb_embedded_profile(
+                                        img_filename)
+                                    print('Convert CMYK (embedded) to '
+                                          'RGB: {}'.format(img_filename))
+                                else:
+                                    cmd = _convert_cmyk2rgb_no_profile(
+                                        img_filename)
+                                    print('Convert CMYK (no profile) to '
+                                          'RGB: {}'.format(img_filename))
+                                if profile.is_file():
+                                    profile.unlink()  # delete file
+                        else:
+                            cmd = _universal_convert_rgb_command(img_filename)
+                            print('Warning: Convert exceptional color '
+                                  'space {} to RGB: {}'.format(colorspace, img_filename))
+                        # convert command itself
+                        fconvert = await asyncio.create_subprocess_shell(
+                            cmd, stdout=asyncio.subprocess.PIPE,
+                            stderr=asyncio.subprocess.PIPE)
+                        stdout, stderr = await fconvert.communicate()
+                        if fconvert.returncode != 0:
+                            raise Exception('Error converting file {}'.format(img_filename) +
+                                            ' to RGB color space: {}'.format(stderr))
+            except UnidentifiedImageError:  # pragma: no cover
+                # do nothing if we cannot open the image
+                print('Warning: Could not parse JPEG image with PIL: ' + str(img_filename))
+    else:
+        raise Exception('Error: Resource file not existing: ' + str(img_filename))  # pragma: no cover
+
+
+class AsyncJobQueue:
+    def __init__(self, worker_count, qsize=None):
+        self.worker_count = worker_count
+        self.queue = (asyncio.Queue(qsize) if qsize is not None
+                      else asyncio.Queue())
+        self.workers = []
+
+    async def __aenter__(self):
+        async def worker(queue):
+            while True:
+                try:
+                    job = await queue.get()
+                    await job
+                    queue.task_done()
+                except Exception as e:  # pragma: no cover
+                    # No way to communicate the error back at the moment
+                    sys.exit(e)
+        self.workers = [asyncio.create_task(worker(self.queue))
+                        for _ in range(self.worker_count)]
+        return self.queue
+
+    async def __aexit__(self, *_):
+        await self.queue.join()
+        for worker in self.workers:
+            worker.cancel()
+
+
+def get_img_resources(doc, out_dir):
+    """Iterates over all image resources--absolute paths--in the document"""
 
     # get all img resources from img and a nodes
     # assuming all resources from checksum step are in the same folder
@@ -132,65 +218,10 @@ def fix_jpeg_colorspace(doc, out_dir):
                           namespaces={'x': 'http://www.w3.org/1999/xhtml'}):
         img_filename = Path(node)
         img_filename = (out_dir / img_filename).resolve().absolute()
-
-        if img_filename.is_file():
-            mime_type = utils.get_mime_type(str(img_filename))
-
-            # Only check colorspace of JPEGs (GIF, PNG etc. don't have breaking colorspaces)
-            if mime_type == 'image/jpeg':
-                try:
-                    im = Image.open(str(img_filename))
-                    # https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
-                    colorspace = im.mode
-                    im.close()
-                    if not re.match(r"^RGB.*", colorspace):  # pragma: no cover
-                        if colorspace != '1' and not re.match(r"^L\w?", colorspace):
-                            # here we have a color space like CMYK or YCbCr most likely
-                            # decide which command line to use
-                            if colorspace == 'CMYK':
-                                with TemporaryDirectory() as temp_dir:
-                                    profile = Path(temp_dir) / Path('embedded.icc')
-                                    # save embedded profile if existing
-                                    cmd = ['convert', str(img_filename), str(profile)]
-                                    extractembedded = subprocess.Popen(cmd,
-                                                                       stdout=subprocess.PIPE,
-                                                                       stderr=subprocess.PIPE)
-                                    stdout, stderr = extractembedded.communicate()
-                                    # was there an embedded icc profile?
-                                    if extractembedded.returncode == 0 and \
-                                            profile.is_file() and \
-                                            profile.stat().st_size > 0:
-                                        cmd = _convert_cmyk2rgb_embedded_profile(
-                                            img_filename)
-                                        print('Convert CMYK (embedded) to '
-                                              'RGB: {}'.format(node))
-                                    else:
-                                        cmd = _convert_cmyk2rgb_no_profile(
-                                            img_filename)
-                                        print('Convert CMYK (no profile) to '
-                                              'RGB: {}'.format(node))
-                                    if profile.is_file():
-                                        profile.unlink()  # delete file
-                            else:
-                                cmd = _universal_convert_rgb_command(img_filename)
-                                print('Warning: Convert exceptional color '
-                                      'space {} to RGB: {}'.format(colorspace, node))
-                            # convert command itself
-                            fconvert = subprocess.Popen(cmd,
-                                                        stdout=subprocess.PIPE,
-                                                        stderr=subprocess.PIPE)
-                            stdout, stderr = fconvert.communicate()
-                            if fconvert.returncode != 0:
-                                raise Exception('Error converting file {}'.format(img_filename) +
-                                                ' to RGB color space: {}'.format(stderr))
-                except UnidentifiedImageError:  # pragma: no cover
-                    # do nothing if we cannot open the image
-                    print('Warning: Could not parse JPEG image with PIL: ' + str(img_filename))
-        else:
-            raise Exception('Error: Resource file not existing: ' + str(img_filename))  # pragma: no cover
+        yield img_filename
 
 
-def main():
+async def run_async():
     in_dir = Path(sys.argv[1]).resolve(strict=True)
     out_dir = Path(sys.argv[2]).resolve(strict=True)
     book_slugs_file = Path(sys.argv[3]).resolve(strict=True)
@@ -211,16 +242,22 @@ def main():
             elem["uuid"]: elem["slug"] for elem in json_data
         }
 
-    for xhtml_file in xhtml_files:
-        doc = etree.parse(str(xhtml_file))
-        update_doc_links(
-            doc,
-            book_uuid,
-            book_slugs_by_uuid
-        )
-        patch_math(doc)
-        fix_jpeg_colorspace(doc, out_dir)
-        doc.write(str(out_dir / xhtml_file.name), encoding="utf8")
+    async with AsyncJobQueue(20) as queue:
+        for xhtml_file in xhtml_files:
+            doc = etree.parse(str(xhtml_file))
+            update_doc_links(
+                doc,
+                book_uuid,
+                book_slugs_by_uuid
+            )
+            patch_math(doc)
+            for img_filename in get_img_resources(doc, out_dir):
+                queue.put_nowait(fix_jpeg_colorspace(img_filename))  # pragma: no cover
+            doc.write(str(out_dir / xhtml_file.name), encoding="utf8")
+
+
+def main():  # pragma: no cover
+    asyncio.run(run_async())
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/bakery-src/scripts/setup.py
+++ b/bakery-src/scripts/setup.py
@@ -21,6 +21,7 @@ tests_require = [
     'pytest',
     'pytest-mock',
     'pytest-cov',
+    'pytest-asyncio',
     'flake8',
     'requests-mock'
 ]

--- a/test/test-step-10.bash
+++ b/test/test-step-10.bash
@@ -11,7 +11,7 @@ fi
 pip install "../bakery-src/scripts/.[test]"
 flake8 "../bakery-src/scripts" --max-line-length=110
 
-pytest --cov=bakery_scripts --cov-append --cov-report=xml:cov.xml --cov-report=html:cov.html --cov-report=term  ../bakery-src -vvv
+pytest --asyncio-mode=strict --cov=bakery_scripts --cov-append --cov-report=xml:cov.xml --cov-report=html:cov.html --cov-report=term  ../bakery-src -vvv
 sed -i 's/filename=".*\/bakery_scripts/filename="/g' cov.xml
 
 # Upload to codecov only if running inside CI


### PR DESCRIPTION
- [ ] openstax/ce#1914


## Given
* A valid git book

## When
* You build the repository into a doc using a script like this one
```sh
repo="osbooks-calculus-bundle"
slug="calculus-volume-1"
book_dir="./data/$(basename "$repo")"
./enki --command all-git-gdoc  --data-dir "$book_dir" --repo "$repo" --book-slug "$slug" --ref main --style default
```

## Then
* You will find the finished docs in `$book_dir/_attic/IO_DOCX`
* The build should succeed and all the correct content should exist in the finished docs.
* Everything should work the same as before except the git-gdocify step will, hopefully, complete in less time

---
### Summary of Changes

Add an async queue that allows converting multiple images at a time. The worker count, 20, may need to be tweaked depending on the environment. In my testing on Gitpod, having 20 workers converting images concurrently allowed processing of 3.4 images per second. That is opposed to the old rate of 0.64 images per second.

The async job queue is an async context manager that joins the queue--waiting for all pending work--upon exiting the context. This creates a very simple fire-and-forget system.

I had to upgrade the python version used for tests to 3.8 because there seems to be a problem with pytest-asyncio on version 3.7. Python version 3.8.10 is used in the Enki image anyway. Consequently, this change should help the test more closely match the production environment too!