### PR TITLE
Update docx links independently for each book slug

### DIFF
--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -1588,10 +1588,6 @@ async def test_gdocify_book(tmp_path, mocker):
         "slug": "l1-page-slug"
     }
 
-    book_metadata = {
-        "id": "bookuuid1"
-    }
-
     book_slugs = [
         {
             "uuid": "bookuuid1",
@@ -1606,8 +1602,6 @@ async def test_gdocify_book(tmp_path, mocker):
     # Populate a dummy TOC to confirm it is ignored
     toc_input = input_dir / "collection.toc.xhtml"
     toc_input.write_text("DUMMY")
-    book_metadata_input = input_dir / "collection.toc-metadata.json"
-    book_metadata_input.write_text(json.dumps(book_metadata))
     page_name = "bookuuid1@version:pageuuid1.xhtml"
     page_input = input_dir / page_name
     page_input.write_text(page_content)
@@ -1619,7 +1613,7 @@ async def test_gdocify_book(tmp_path, mocker):
     l1_page_metadata_input.write_text(json.dumps(l1_page_metadata))
 
     # Test complete script
-    mocker.patch("sys.argv", ["", input_dir, output_dir, book_slugs_input, book_metadata_input])
+    mocker.patch("sys.argv", ["", input_dir, output_dir, book_slugs_input])
     await gdocify_book.run_async()
 
     page_output = output_dir / page_name

--- a/dockerfiles/steps/git-gdocify.bash
+++ b/dockerfiles/steps/git-gdocify.bash
@@ -30,5 +30,5 @@ done < <(try xmlstarlet sel -t --match "$xpath_sel" --value-of '@slug' --value-o
 # Save all the slug/uuid pairs into a JSON file
 try jo -a $jo_args > $book_slugs_file
 
-try gdocify "$IO_JSONIFIED" "$IO_GDOCIFIED/content" "$book_slugs_file" "$IO_JSONIFIED/$(cat "$IO_BOOK/slug").toc.json"
+try gdocify "$IO_JSONIFIED" "$IO_GDOCIFIED/content" "$book_slugs_file"
 try cp "$IO_DISASSEMBLE_LINKED"/*@*-metadata.json "$IO_GDOCIFIED/content"


### PR DESCRIPTION
- [ ] openstax/CE#1934

## Prerequisites 
* Have the enki repository cloned from GitHub
* Be in the root directory of enki
* If you want to build with a private repo, you will need to [create and set a GitHub access token](https://github.com/openstax/enki#set-a-github-token)

## Given
- A valid bundled book repo (osbooks-...-bundle)
## When
- Building to docx (i.e. all-git-gdocify)
##  Then
- Links within the docx files that go to openstax.org should work for each book slug
    - Note: When you see more than one of the same `chapter-section` pair, that is a good indication that those documents are from different book slugs (example:  9-1-title-here.docx vs. 9-1-different-title.docx would be from different book slugs)


## Summary of changes

Update docx links for all modules using their respective book slug/uuid.

Remove use of *.toc.json file since we were only using the uuid from it
and we already have that in our slugs_by_uuid dict.