### PR TITLE
Use book slug as directory during docx conversion

### DIFF
--- a/dockerfiles/steps/git-convert-docx.bash
+++ b/dockerfiles/steps/git-convert-docx.bash
@@ -1,23 +1,30 @@
 # LCOV_EXCL_START
-try pushd $BAKERY_SCRIPTS_ROOT/scripts/
-try $BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2 start mml2svg2png-json-rpc.js --node-args="-r esm" --wait-ready --listen-timeout 8000
+try pushd "$BAKERY_SCRIPTS_ROOT/scripts/"
+try "$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" start mml2svg2png-json-rpc.js --node-args="-r esm" --wait-ready --listen-timeout 8000
 try popd
-try cp -r $IO_GDOCIFIED/. $IO_DOCX
+try cp -r "$IO_GDOCIFIED/." "$IO_DOCX"
 book_dir="$IO_DOCX/content"
 target_dir="$IO_DOCX/docx"
 try mkdir -p "$target_dir"
 try cd "$book_dir"
-for xhtmlfile in ./*@*.xhtml; do
-    xhtmlfile_basename=$(basename "$xhtmlfile")
-    metadata_filename="${xhtmlfile_basename%.*}"-metadata.json
-    docx_filename=$(cat "$metadata_filename" | jq -r '.slug').docx
-    mathmltable_tempfile="$xhtmlfile.mathmltable.tmp"
-    try mathmltable2png "$xhtmlfile" "../resources" "$mathmltable_tempfile"
-    wrapped_tempfile="$xhtmlfile.greybox.tmp"
-    
-    say "Converting to docx: $xhtmlfile_basename"
-    try xsltproc --output "$wrapped_tempfile" $BAKERY_SCRIPTS_ROOT/scripts/gdoc/wrap-in-greybox.xsl "$mathmltable_tempfile"
-    try pandoc --reference-doc="$BAKERY_SCRIPTS_ROOT/scripts/gdoc/custom-reference.docx" --from=html --to=docx --output="../../../$target_dir/$docx_filename" "$wrapped_tempfile"
-done
-try $BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2 stop mml2svg2png-json-rpc
+
+col_sep='|'
+while read -r line; do
+    IFS=$col_sep read -r slug uuid <<< "$line"
+    current_target="$(realpath "$target_dir/$slug")"
+    [[ -d "$current_target" ]] || mkdir "$current_target"
+    for xhtmlfile in ./"$uuid@"*.xhtml; do
+        xhtmlfile_basename=$(basename "$xhtmlfile")
+        metadata_filename="${xhtmlfile_basename%.*}"-metadata.json
+        docx_filename=$(jq -r '.slug' "$metadata_filename").docx
+        mathmltable_tempfile="$xhtmlfile.mathmltable.tmp"
+        try mathmltable2png "$xhtmlfile" "../resources" "$mathmltable_tempfile"
+        wrapped_tempfile="$xhtmlfile.greybox.tmp"
+
+        say "Converting to docx: $xhtmlfile_basename"
+        try xsltproc --output "$wrapped_tempfile" "$BAKERY_SCRIPTS_ROOT/scripts/gdoc/wrap-in-greybox.xsl" "$mathmltable_tempfile"
+        try pandoc --reference-doc="$BAKERY_SCRIPTS_ROOT/scripts/gdoc/custom-reference.docx" --from=html --to=docx --output="$current_target/$docx_filename" "$wrapped_tempfile"
+    done
+done < <(try jq -r '.[] | .slug + "'$col_sep'" + .uuid' "$IO_GDOCIFIED/content/book-slugs.json")
+try "$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" stop mml2svg2png-json-rpc
 # LCOV_EXCL_STOP

--- a/dockerfiles/steps/git-gdocify.bash
+++ b/dockerfiles/steps/git-gdocify.bash
@@ -2,7 +2,7 @@
 [[ -d "$IO_GDOCIFIED/content" ]] || mkdir "$IO_GDOCIFIED/content"
 try cp -R "$IO_RESOURCES/." "$IO_GDOCIFIED/resources"
 
-book_slugs_file="/tmp/book-slugs.json"
+book_slugs_file="$IO_GDOCIFIED/content/book-slugs.json"
 
 jo_args=''
 
@@ -28,7 +28,8 @@ while read -r line; do # Loop over each <book> entry in the META-INF/books.xml m
 done < <(try xmlstarlet sel -t --match "$xpath_sel" --value-of '@slug' --value-of "'$col_sep'" --value-of '@href' --value-of "'$col_sep'" --value-of '@style' --nl < $repo_root/META-INF/books.xml)
 
 # Save all the slug/uuid pairs into a JSON file
-try jo -a $jo_args > $book_slugs_file
+# NOTE: This file is also used in convert-docx
+try jo -a $jo_args > "$book_slugs_file"
 
 try gdocify "$IO_JSONIFIED" "$IO_GDOCIFIED/content" "$book_slugs_file"
 try cp "$IO_DISASSEMBLE_LINKED"/*@*-metadata.json "$IO_GDOCIFIED/content"


### PR DESCRIPTION
- [ ] openstax/ce#1935

This is meant to preserve page slugs that share the same name between
book slugs (i.e. 1-summary in volume 1 vs 1-summary in volume-2).
Prior to this change, page slugs with the same name were being
overwritten in the process of building bundles.

Another option would be to add the book slug to the beginning of each
file name ({book_slug}-{page_slug}.docx). I decided to use directories
because it makes it easier to inspect the output of the build when
needed.

The other option might make more sense when uploading the files to
an external service. If that happens, we can flatten the directories
and add the book slug to the name of each docx file as it is uploaded.