### PR TITLE
Remove iframes before converting to docx

### DIFF
--- a/bakery-src/scripts/gdocify_book.py
+++ b/bakery-src/scripts/gdocify_book.py
@@ -257,6 +257,14 @@ def patch_math(doc):
                 node.tag = node_type
 
 
+def remove_iframes(doc):
+    for node in doc.xpath(
+            '//x:iframe',
+            namespaces={"x": "http://www.w3.org/1999/xhtml"}
+    ):
+        node.getparent().remove(node)
+
+
 def _convert_cmyk2rgb_embedded_profile(img_filename):
     """ImageMagick commandline to convert from CMYK with
     an existing embedded icc profile"""
@@ -418,6 +426,7 @@ async def run_async():
                     book_slugs_by_uuid
                 )
                 patch_math(doc)
+                remove_iframes(doc)
                 for img_filename in get_img_resources(doc, out_dir):
                     if img_filename not in queued_items:  # pragma: no cover
                         queued_items.add(img_filename)

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -1529,6 +1529,7 @@ async def test_gdocify_book(tmp_path, mocker):
             data-page-slug="l1-page-slug"
             data-page-fragment="foobar"
             class="target-chapter">Intra-book module link with fragment</a></p>
+        <p><iframe src="http://www.example.com/"></iframe></p>
         <math>
             <mrow>
                 <mtext mathvariant="bold-italic">x</mtext>
@@ -1767,6 +1768,12 @@ async def test_gdocify_book(tmp_path, mocker):
         namespaces={"x": "http://www.w3.org/1999/xhtml"},
     )
     assert len(msub_nodes) == 1
+
+    unwanted_nodes = updated_doc.xpath(
+        '//x:iframe',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    )
+    assert len(unwanted_nodes) == 0
 
     # Test fix_jpeg_colorspace
 


### PR DESCRIPTION
- [ ] openstax/CE#1947

- Would it be worthwhile to throw an error if an iframe targeted for removal is not accompanied by a link to the embedded content?
- Is the linking consistent enough for something like this to work? 

Initially, I only removed iframes contained inside elements with the `os-has-link` and `os-has-iframe` classes; however, that left a few iframes behind. I was hoping that the iframes left behind would cause errors; however, the iframe in osbooks-physics is the only one I have found so far that causes problems.