### PR TITLE
1933 Change mn/mi containing u0338 to mtext for docx

### DIFF
--- a/bakery-src/scripts/gdocify_book.py
+++ b/bakery-src/scripts/gdocify_book.py
@@ -256,6 +256,15 @@ def patch_math(doc):
                     f'Converting mo to {node_type}: "{log_text}"')
                 node.tag = node_type
 
+    # Pandoc converts \u0338 to \not{}. This causes problems in mi and mn tags.
+    # Convert to mtext.
+    for node in doc.xpath(
+            '//x:mi[contains(text(), "\u0338")]|//x:mn[contains(text(), "\u0338")]',
+            namespaces={"x": "http://www.w3.org/1999/xhtml"}
+    ):
+        logging.warning("Found \\u0338 in math: converting to mtext")
+        node.tag = "mtext"
+
 
 def remove_iframes(doc):
     for node in doc.xpath(

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -1613,6 +1613,9 @@ async def test_gdocify_book(tmp_path, mocker):
                 <mrow>
                     <mo>&#x00a0;</mo>
                 </mrow>
+                <mrow>
+                    <mn>4̸</mn>
+                </mrow>
             </semantics>
         </math>
         </div>
@@ -1712,7 +1715,7 @@ async def test_gdocify_book(tmp_path, mocker):
 
     assert(
         "mtext" == updated_doc.xpath(
-            f'//*[text() = "{chr(0xa0)}"]',
+            '//*[text() = "\xa0"]',
             namespaces={"x": "http://www.w3.org/1999/xhtml"},
         )[0].tag.split("}")[1]
     )
@@ -1771,6 +1774,12 @@ async def test_gdocify_book(tmp_path, mocker):
 
     unwanted_nodes = updated_doc.xpath(
         '//x:iframe',
+        namespaces={"x": "http://www.w3.org/1999/xhtml"},
+    )
+    assert len(unwanted_nodes) == 0
+
+    unwanted_nodes = updated_doc.xpath(
+        f'//x:mi[contains(text(), "\u0338")]|//x:mn[contains(text(), "\u0338")]',
         namespaces={"x": "http://www.w3.org/1999/xhtml"},
     )
     assert len(unwanted_nodes) == 0


### PR DESCRIPTION
- [ ] openstax/CE#1933

## Given
* osbooks-prealgebra-bundle
## When
* Building the book to docx with CORGI
## Then
* The build passes
* The solutions in 4-3-multiply-and-divide-mixed-numbers-and-complex-fractions.docx look similar to what is [online](https://openstax.org/books/prealgebra-2e/pages/4-3-multiply-and-divide-mixed-numbers-and-complex-fractions#fs-id1409316). Specifically, there should still be slashes over numbers in numerators and denominators to show that the factors "cancel out".

---

## Summary of Changes

The slash character used to cross out a number, \u0338, seems to cause translation errors when it is inside mi or mn tags; however, it is fine inside mtext. This PR adds a patch to gdocify_book.py that converts mi and mn tags to mtext if they contain \u0338. The math should still look very similar to what is online. 