### PR TITLE
calculate width and height on resources

### DIFF
--- a/bakery-src/scripts/fetch_map_resources.py
+++ b/bakery-src/scripts/fetch_map_resources.py
@@ -16,13 +16,15 @@ from . import utils
 RESOURCES_DIR_NAME = 'resources'
 
 
-def create_json_metadata(output_dir, sha1, mime_type, s3_md5, original_name):
+def create_json_metadata(output_dir, sha1, mime_type, s3_md5, original_name, width, height):
     """ Create json with MIME type of a (symlinked) resource file """
     data = {}
     data['original_name'] = original_name
     data['mime_type'] = mime_type
     data['s3_md5'] = s3_md5
     data['sha1'] = sha1
+    data['width'] = width
+    data['height'] = height
     json_file = output_dir / f'{sha1}.json'
     with json_file.open(mode='w') as outfile:
         json.dump(data, outfile)
@@ -59,6 +61,7 @@ def main():
                 str(resource_original_filepath)
             )
             mime_type = utils.get_mime_type(str(resource_original_filepath))
+            width, height = utils.get_size(str(resource_original_filepath))
 
             if sha1 is None:
                 print(
@@ -102,7 +105,8 @@ def main():
         checksum_resource_file = resources_dir / sha1
 
         shutil.move(str(resource_original_filepath), str(checksum_resource_file))
-        create_json_metadata(resources_dir, sha1, mime_type, s3_md5, resource_original_name)
+        create_json_metadata(
+            resources_dir, sha1, mime_type, s3_md5, resource_original_name, width, height)
 
     # NOTE: As part of CNX-1274 (https://github.com/openstax/cnx/issues/1274),
     # we're adding support for relative image URLs which may mean over time

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -2509,12 +2509,14 @@ def test_fetch_map_resources(tmp_path, mocker):
     fetch_map_resources.main()
 
     assert json.load((resources_dir / image_src_meta).open()) == {
+        'height': 30,
         'mime_type': 'image/svg+xml',
         'original_name': 'image_src.svg',
         # AWS needs the MD5 quoted inside the string json value.
         # Despite looking like a mistake, this is correct behavior.
         's3_md5': f'"{image_src_md5_expected}"',
-        'sha1': image_src_sha1_expected
+        'sha1': image_src_sha1_expected,
+        'width': 120
     }
     assert set(file.name for file in resources_dir.glob('**/*')) == set([
         image_src_sha1_expected,


### PR DESCRIPTION
fixes key error web pipeline. Pipeline `all-git-web` calculates checksums of resources in `fetch_map_resources.py`

Only old pipeline `all-archive-web` uses the `checksum_resource.py` file nowadays.