### PR TITLE
Various fixes related to parse_book_dir

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -153,8 +153,6 @@ function parse_book_dir() {
     [[ -f $IO_BOOK/repo ]] && ARG_REPO_NAME="$(cat $IO_BOOK/repo)"
     [[ -f $IO_BOOK/slug ]] && ARG_TARGET_SLUG_NAME="$(cat $IO_BOOK/slug)"
     ARG_GIT_REF="$(cat $IO_BOOK/version)"
-    [[ "$ARG_GIT_REF" == latest ]] && ARG_GIT_REF=main
-    [[ "$ARG_REPO_NAME" == */* ]] || ARG_REPO_NAME="openstax/$ARG_REPO_NAME"
 }
 
 # Concourse-CI runs each step in a separate process so parse_book_dir() needs to

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -153,6 +153,8 @@ function parse_book_dir() {
     [[ -f $IO_BOOK/repo ]] && ARG_REPO_NAME="$(cat $IO_BOOK/repo)"
     [[ -f $IO_BOOK/slug ]] && ARG_TARGET_SLUG_NAME="$(cat $IO_BOOK/slug)"
     ARG_GIT_REF="$(cat $IO_BOOK/version)"
+    [[ "$ARG_GIT_REF" == latest ]] && ARG_GIT_REF=main
+    [[ "$ARG_REPO_NAME" == */* ]] || ARG_REPO_NAME="openstax/$ARG_REPO_NAME"
 }
 
 # Concourse-CI runs each step in a separate process so parse_book_dir() needs to

--- a/dockerfiles/steps/git-assemble-epub.bash
+++ b/dockerfiles/steps/git-assemble-epub.bash
@@ -60,9 +60,6 @@ shopt -u globstar
 col_sep='|'
 # https://stackoverflow.com/a/31838754
 xpath_sel="//*[@slug]" # All the book entries
-if [[ $ARG_TARGET_SLUG_NAME ]]; then
-    xpath_sel="//*[@slug=\"$ARG_TARGET_SLUG_NAME\"]" # LCOV_EXCL_LINE
-fi
 while read -r line; do # Loop over each <book> entry in the META-INF/books.xml manifest
     IFS=$col_sep read -r slug href _ <<< "$line"
     path="$repo_root/META-INF/$href"

--- a/dockerfiles/steps/git-assemble.bash
+++ b/dockerfiles/steps/git-assemble.bash
@@ -4,9 +4,6 @@ repo_root=$IO_FETCH_META
 col_sep='|'
 # https://stackoverflow.com/a/31838754
 xpath_sel="//*[@slug]" # All the book entries
-if [[ $ARG_TARGET_SLUG_NAME ]]; then
-    xpath_sel="//*[@slug=\"$ARG_TARGET_SLUG_NAME\"]" # LCOV_EXCL_LINE
-fi
 while read -r line; do # Loop over each <book> entry in the META-INF/books.xml manifest
     IFS=$col_sep read -r slug href _ <<< "$line"
     path="$repo_root/META-INF/$href"

--- a/dockerfiles/steps/git-fetch-metadata.bash
+++ b/dockerfiles/steps/git-fetch-metadata.bash
@@ -1,5 +1,7 @@
 parse_book_dir
 
+[[ "$ARG_GIT_REF" == latest ]] && ARG_GIT_REF=main
+
 try cp -R "$IO_FETCHED/." "$IO_FETCH_META"
 
 # Based on https://github.com/openstax/content-synchronizer/blob/e04c05fdce7e1bbba6a61a859b38982e17b74a16/resource-synchronizer/sync.sh#L19-L32

--- a/dockerfiles/steps/git-fetch.bash
+++ b/dockerfiles/steps/git-fetch.bash
@@ -1,5 +1,8 @@
 parse_book_dir
 
+[[ "$ARG_GIT_REF" == latest ]] && ARG_GIT_REF=main
+[[ "$ARG_REPO_NAME" == */* ]] || ARG_REPO_NAME="openstax/$ARG_REPO_NAME"
+
 creds_dir=$(pwd)/tmp-gh-creds
 
 # Support sideloading the book

--- a/dockerfiles/steps/git-fetch.bash
+++ b/dockerfiles/steps/git-fetch.bash
@@ -1,6 +1,4 @@
 parse_book_dir
-[[ "$ARG_GIT_REF" == latest ]] && ARG_GIT_REF=main
-[[ "$ARG_REPO_NAME" == */* ]] || ARG_REPO_NAME="openstax/$ARG_REPO_NAME"
 
 creds_dir=$(pwd)/tmp-gh-creds
 


### PR DESCRIPTION
* Make sure git-fetch and git-fetch-metadata use the same logic to determine which git ref to use
* Remove zombie code that caused only one book to be assembled while building a bundle.