### PR TITLE
:bug: fix unbound variable when running in a webhosting pipeline

### DIFF
--- a/dockerfiles/steps/git-fetch.bash
+++ b/dockerfiles/steps/git-fetch.bash
@@ -92,6 +92,7 @@ fi
 
 # If the user wants to build one book then check that the book exists
 # so we can error early.
+ARG_TARGET_SLUG_NAME=${ARG_TARGET_SLUG_NAME:-}
 if [[ $ARG_TARGET_SLUG_NAME ]]; then
     manifest_file="$IO_FETCHED/META-INF/books.xml"
     set +e


### PR DESCRIPTION
This came up when deploying a webhosting pipeline. Validating unbound variables in bash was added as part of the EPUB PR