### PR TITLE
Get M1 Mac to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@
 # Run ./build-dockerfile.sh instead.
 # ====================================================
 # vvvvvvvvvvvvvvv Dockerfile.common vvvvvvvvvvvvvvv
-FROM sudobmitch/base:scratch as base-scratch
 FROM buildpack-deps:focal as base
 
 
@@ -32,6 +31,8 @@ FROM buildpack-deps:focal as base
 RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
+    # ... for docker-entrypoint
+    gosu \
     # ... for princexml:
     gdebi fonts-stix libcurl4 \
     # ... for bakery-scripts
@@ -317,8 +318,6 @@ RUN set -x \
 RUN mv /root/.nvm $PROJECT_ROOT/nvm
 ENV PATH=$PATH:$PROJECT_ROOT/nvm/versions/node/v$NODE_VERSION/bin/
 
-COPY --from=base-scratch / /
-
 ENV EPUB_VALIDATOR_VERSION=4.2.6
 RUN mkdir $PROJECT_ROOT/epub-validator \
     && cd $PROJECT_ROOT/epub-validator \
@@ -348,6 +347,7 @@ COPY ./ce-styles/styles/output/ $PROJECT_ROOT/ce-styles/styles/output/
 
 
 ENV PATH=$PATH:/dockerfiles/
+COPY ./dockerfiles/fix-perms /usr/bin/
 COPY ./dockerfiles/10-fix-perms.sh /etc/entrypoint.d/
 COPY ./dockerfiles/steps /dockerfiles/steps
 COPY ./dockerfiles/build /dockerfiles/build

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -1,4 +1,3 @@
-FROM sudobmitch/base:scratch as base-scratch
 FROM buildpack-deps:focal as base
 
 
@@ -11,6 +10,8 @@ FROM buildpack-deps:focal as base
 RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
+    # ... for docker-entrypoint
+    gosu \
     # ... for princexml:
     gdebi fonts-stix libcurl4 \
     # ... for bakery-scripts
@@ -296,8 +297,6 @@ RUN set -x \
 RUN mv /root/.nvm $PROJECT_ROOT/nvm
 ENV PATH=$PATH:$PROJECT_ROOT/nvm/versions/node/v$NODE_VERSION/bin/
 
-COPY --from=base-scratch / /
-
 ENV EPUB_VALIDATOR_VERSION=4.2.6
 RUN mkdir $PROJECT_ROOT/epub-validator \
     && cd $PROJECT_ROOT/epub-validator \
@@ -327,6 +326,7 @@ COPY ./ce-styles/styles/output/ $PROJECT_ROOT/ce-styles/styles/output/
 
 
 ENV PATH=$PATH:/dockerfiles/
+COPY ./dockerfiles/fix-perms /usr/bin/
 COPY ./dockerfiles/10-fix-perms.sh /etc/entrypoint.d/
 COPY ./dockerfiles/steps /dockerfiles/steps
 COPY ./dockerfiles/build /dockerfiles/build

--- a/dockerfiles/fix-perms
+++ b/dockerfiles/fix-perms
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+# Source: https://github.com/sudo-bmitch/docker-base/blob/main/bin/fix-perms
+# Copyright: Brandon Mitchell
+# License: MIT
+
+opt_h=0
+opt_r=0
+
+while getopts 'g:hru:' option; do
+  case $option in
+    g) opt_g="$OPTARG";;
+    h) opt_h=1;;
+    r) opt_r=1;;
+    u) opt_u="$OPTARG";;
+  esac
+done
+shift $(expr $OPTIND - 1)
+
+if [ $# -lt 1 -o "$opt_h" = "1" -o \( -z "$opt_g" -a -z "$opt_u" \) ]; then
+  echo "Usage: $(basename $0) [opts] path"
+  echo " -g group_name: group name to adjust gid"
+  echo " -h: this help message"
+  echo " -r: recursively update uid/gid on root filesystem"
+  echo " -u user_name: user name to adjust uid"
+  echo "Either -u or -g must be provided in addition to a path. The uid and"
+  echo "gid of the path will be used to modify the uid/gid inside the"
+  echo "container. e.g.: "
+  echo "  $0 -g app_group -u app_user -r /path/to/vol/data"
+  [ "$opt_h" = "1" ] && exit 0 || exit 1
+fi
+
+if [ "$(id -u)" != "0" ]; then
+  echo "Root required for $(basename $0)"
+  exit 1
+fi
+
+if [ ! -e "$1" ]; then
+  echo "File or directory does not exist, skipping fix-perms: $1"
+  exit 0
+fi
+
+if ! type usermod >/dev/null 2>&1 || \
+   ! type groupmod >/dev/null 2>&1; then
+  if type apk /dev/null 2>&1; then
+    echo "Warning: installing shadow, this should be included in your image"
+    apk add --no-cache shadow
+  else
+    echo "Commands usermod and groupmod are required."
+    exit 1
+  fi
+fi
+
+set -e
+
+# update the uid
+if [ -n "$opt_u" ]; then
+  OLD_UID=$(getent passwd "${opt_u}" | cut -f3 -d:)
+  NEW_UID=$(stat -c "%u" "$1")
+  if [ "$OLD_UID" != "$NEW_UID" ]; then
+    echo "Changing UID of $opt_u from $OLD_UID to $NEW_UID"
+    usermod -u "$NEW_UID" -o "$opt_u"
+    if [ -n "$opt_r" ]; then
+      find / -xdev -user "$OLD_UID" -exec chown -h "$opt_u" {} \;
+    fi
+  fi
+fi
+
+# update the gid
+if [ -n "$opt_g" ]; then
+  OLD_GID=$(getent group "${opt_g}" | cut -f3 -d:)
+  NEW_GID=$(stat -c "%g" "$1")
+  if [ "$OLD_GID" != "$NEW_GID" ]; then
+    echo "Changing GID of $opt_g from $OLD_GID to $NEW_GID"
+    groupmod -g "$NEW_GID" -o "$opt_g"
+    if [ -n "$opt_r" ]; then
+      find / -xdev -group "$OLD_GID" -exec chgrp -h "$opt_g" {} \;
+    fi
+  fi
+fi

--- a/enki
+++ b/enki
@@ -254,9 +254,9 @@ $root_dir/build-dockerfile.sh
 }
 
 [[ $SKIP_DOCKER_BUILD ]] || {
-    DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker build --tag $image_name --file $root_dir/Dockerfile $root_dir/.
+    DOCKER_DEFAULT_PLATFORM=linux/amd64 DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker build --tag $image_name --file $root_dir/Dockerfile $root_dir/.
 }
-docker run $interactive $enable_tty \
+DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run $interactive $enable_tty \
     $opt_sideload_book_arg \
     --volume="$(cd "$data_dir"/; pwd):/data/" \
     $opt_mount_recipes \


### PR DESCRIPTION
This forces non-amd64 architectures (like the Apple M1) to run in emulation mode.

This is a stop-gap solution while we upgrade all the dependencies to enable an arm64 image.