### PR TITLE
Fix for the bad href error

### DIFF
--- a/bakery-src/scripts/html_parser.py
+++ b/bakery-src/scripts/html_parser.py
@@ -213,15 +213,17 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
             if ref_val in id_map:
                 target_page, target = id_map[ref_val]
                 if page == target_page:  # pragma: no cover
-                    i.attrib['href'] = f'#{target}'
+                    i.attrib['href'] = '#{}'.format(target)
                 else:
                     target_id = target_page.id.split('@')[0]
                     if not target:  # link to page
-                        i.attrib['href'] = f'/contents/{target_id}'  # pragma: no cover
+                        i.attrib['href'] = '/contents/{}'.format(
+                            target_id)  # pragma: no cover
                     else:
-                        i.attrib['href'] = f'/contents/{target_id}#{target}'
+                        i.attrib['href'] = '/contents/{}#{}'.format(
+                            target_id, target)
             else:
-                print(f'Bad href: {ref_val}')  # pragma: no cover
+                Logger.error(f'Bad href: {ref_val}')  # pragma: no cover
 
         page.content = cnx_models.etree_to_content(content)
 

--- a/bakery-src/scripts/html_parser.py
+++ b/bakery-src/scripts/html_parser.py
@@ -213,18 +213,15 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
             if ref_val in id_map:
                 target_page, target = id_map[ref_val]
                 if page == target_page:  # pragma: no cover
-                    i.attrib['href'] = '#{}'.format(target)
+                    i.attrib['href'] = f'#{target}'
                 else:
                     target_id = target_page.id.split('@')[0]
                     if not target:  # link to page
-                        i.attrib['href'] = '/contents/{}'.format(
-                            target_id)  # pragma: no cover
+                        i.attrib['href'] = f'/contents/{target_id}'  # pragma: no cover
                     else:
-                        i.attrib['href'] = '/contents/{}#{}'.format(
-                            target_id, target)
+                        i.attrib['href'] = f'/contents/{target_id}#{target}'
             else:
-                Logger.error('Bad href: {}'.format(
-                    ref_val))  # pragma: no cover
+                print(f'Bad href: {ref_val}')  # pragma: no cover
 
         page.content = cnx_models.etree_to_content(content)
 

--- a/bakery-src/scripts/html_parser.py
+++ b/bakery-src/scripts/html_parser.py
@@ -1,5 +1,5 @@
 import base64
-from logging import Logger
+import logging
 import re
 import uuid
 from lxml import etree, html
@@ -221,7 +221,7 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                     else:
                         i.attrib['href'] = f'/contents/{target_id}#{target}'
             else:
-                Logger.error(f'Bad href: {ref_val}')  # pragma: no cover
+                logging.error(f'Bad href: {ref_val}')  # pragma: no cover
 
         page.content = cnx_models.etree_to_content(content)
 

--- a/bakery-src/scripts/html_parser.py
+++ b/bakery-src/scripts/html_parser.py
@@ -213,15 +213,13 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
             if ref_val in id_map:
                 target_page, target = id_map[ref_val]
                 if page == target_page:  # pragma: no cover
-                    i.attrib['href'] = '#{}'.format(target)
+                    i.attrib['href'] = f'#{target}'
                 else:
                     target_id = target_page.id.split('@')[0]
                     if not target:  # link to page
-                        i.attrib['href'] = '/contents/{}'.format(
-                            target_id)  # pragma: no cover
+                        i.attrib['href'] = f'/contents/{target_id}'  # pragma: no cover
                     else:
-                        i.attrib['href'] = '/contents/{}#{}'.format(
-                            target_id, target)
+                        i.attrib['href'] = f'/contents/{target_id}#{target}'
             else:
                 Logger.error(f'Bad href: {ref_val}')  # pragma: no cover
 


### PR DESCRIPTION
This fix should solve the following bug that was caused by migrating `cnxepub.html_parser.py` into `enki`
```
  File "/workspace/enki/venv/lib/python3.8/site-packages/bakery_scripts/html_parser.py", line 226, in fix_links
    Logger.error('Bad href: {}'.format(
TypeError: error() missing 1 required positional argument: 'msg'
```