### PR TITLE
Pin python3-poetry to 20220614.214642

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -294,7 +294,7 @@ RUN curl https://codeload.github.com/jpmens/jo/tar.gz/refs/tags/$JO_VERSION > jo
 # Build concourse resource
 # ---------------------------
 
-FROM openstax/python3-poetry as concourse-resource-builder
+FROM openstax/python3-poetry:20220614.214642 as concourse-resource-builder
 
 WORKDIR /code
 COPY ./corgi-concourse-resource .

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -273,7 +273,7 @@ RUN curl https://codeload.github.com/jpmens/jo/tar.gz/refs/tags/$JO_VERSION > jo
 # Build concourse resource
 # ---------------------------
 
-FROM openstax/python3-poetry as concourse-resource-builder
+FROM openstax/python3-poetry:20220614.214642 as concourse-resource-builder
 
 WORKDIR /code
 COPY ./corgi-concourse-resource .


### PR DESCRIPTION
Related to openstax/ce-images#15

I want to pin this image just in case we are using poetry in a way that is no longer supported in the newest version. From what I have seen and read, it should be safe to update; however, I would rather the update be done on our terms than automatically.