### PR TITLE
Quick fix for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install pipenv & Setting up environment
         run: |
           python -m pip install --upgrade pipenv wheel
+          sudo apt-get update
           sudo apt-get install -y imagemagick icc-profiles-free ghostscript
       - id: cache-pipenv
         uses: actions/cache@v1


### PR DESCRIPTION
Ghostscript was not being found. It looks like there is a newer version that we can use instead.