### PR TITLE
simplify bakery-js breakpoints

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,11 @@
-
 vscode:
   extensions:
     - ritwickdey.liveserver
+    - esbenp.prettier-vscode
+    - mads-hartmann.bash-ide-vscode
+    - vscjava.vscode-java-pack
+    - ms-python.python
+
+tasks:
+  # So Prettier will work
+  - init: npm --prefix ./bakery-js/ install

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,7 +40,6 @@
       "request": "attach",
       "continueOnAttach": true,
       "showAsyncStacks": true
-      // "skipFiles": ["<node_internals>/**"]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,13 @@
 {
-    "jest.jestCommandLine": "npm test --"
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ RUN $PROJECT_ROOT/dockerfiles/build/build-stage-bakery-js.sh
 
 COPY ./bakery-js/bin/ $PROJECT_ROOT/bakery-js/bin/
 COPY ./bakery-js/src/ $PROJECT_ROOT/bakery-js/src/
-COPY ./bakery-js/tsconfig.*.json $PROJECT_ROOT/bakery-js/
+COPY ./bakery-js/tsconfig*.json $PROJECT_ROOT/bakery-js/
 RUN cd $PROJECT_ROOT/bakery-js && npm run build
 
 

--- a/bakery-js/bin/bakery-helper
+++ b/bakery-js/bin/bakery-helper
@@ -1,3 +1,11 @@
 #!/usr/bin/env node
 
-require('../dist/index.js')
+if (process.env['JS_DEBUG']) {
+    console.log('Running bakery-js in debugging-mode which converts TypeScript files on the fly so breakpoints work')
+    const path = require('path')
+    const tsconfigFile = path.join(__dirname, '../tsconfig.build.json')
+    require('ts-node').register({project: tsconfigFile})
+    require('../src/index.ts')
+} else {
+    require('../dist/index.js')
+}


### PR DESCRIPTION
They used to require the host to run `npm install && npm build` so VSCode could map to the source TS/TSX files.

Instead, this runs ts-node which transpiles the TS files in-memory which implicitly causes the node debugger to send the path to the TS files to the host (VSCode) rather than the path to the JS file which only exists inside the container