### PR TITLE
Use node for json rpc debugging instead of pm2

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -60,7 +60,8 @@ JS_DEBUG=${JS_DEBUG:-}
 NODE_OPTIONS=${NODE_OPTIONS:-}
 
 if [[ $JS_DEBUG ]]; then
-    export NODE_OPTIONS="--inspect-brk=0.0.0.0:9229" # LCOV_EXCL_LINE
+    export NODE_DEBUG_PORT=9229 # LCOV_EXCL_LINE
+    export NODE_OPTIONS="--inspect-brk=0.0.0.0:$NODE_DEBUG_PORT" # LCOV_EXCL_LINE
 fi
 
 source $PYTHON_VENV_ROOT/bin/activate

--- a/dockerfiles/steps/step-docx.bash
+++ b/dockerfiles/steps/step-docx.bash
@@ -48,9 +48,52 @@ fi
 # LCOV_EXCL_START
 set -Eeuo pipefail
 
-pushd "$BAKERY_SCRIPTS_ROOT/scripts/"
-"$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" start mml2svg2png-json-rpc.js --node-args="-r esm $NODE_OPTIONS" --wait-ready --listen-timeout 8000
-popd
+json_rpc() {
+    case $1 in
+        "start")
+            pushd "$BAKERY_SCRIPTS_ROOT/scripts/"  # for -r esm to work
+            if [[ $JS_DEBUG == 1 ]]; then
+                node -r esm \
+                    $NODE_OPTIONS \
+                    $BAKERY_SCRIPTS_ROOT/scripts/mml2svg2png-json-rpc.js \
+                    &
+                rpc_pid=$!
+                sleep 0.5
+                grep node <(ps -p $rpc_pid) || {
+                    die "Could not start JSON RPC in debug mode"
+                }
+                say "JSON RPC started in debug mode!"
+                say "Please attach a debugger to continue!"
+                # When there are 2 connections on the node debug port, it is
+                # assumed there is:
+                # 1. A listening connection
+                # 2. A debugger connection
+                hex_port=$(printf "%X" $NODE_DEBUG_PORT)
+                while [[ $(grep -c ":$hex_port" /proc/net/tcp) != 2 ]]; do
+                    sleep 0.1
+                done
+            else
+                "$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" \
+                    start \
+                    mml2svg2png-json-rpc.js \
+                    --node-args="-r esm" \
+                    --wait-ready \
+                    --listen-timeout 8000
+            fi
+            popd
+        ;;
+        "stop")
+            if [[ $JS_DEBUG == 1 ]]; then
+                kill $rpc_pid
+            else
+                "$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" stop mml2svg2png-json-rpc
+                "$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" kill
+            fi
+        ;;
+    esac
+}
+
+json_rpc start
 
 book_slugs_file="$(realpath "$IO_DOCX/book-slugs.json")"
 book_dir="$(realpath "$IO_DOCX/content")"
@@ -77,6 +120,5 @@ while read -r line; do
         pandoc --fail-if-warnings --reference-doc="$reference_doc" --from=html --to=docx --output="$current_target/$docx_filename" "$wrapped_tempfile"
     done
 done < <(jq -r '.[] | .slug + "'$col_sep'" + .uuid' "$book_slugs_file")
-"$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" stop mml2svg2png-json-rpc
-"$BAKERY_SCRIPTS_ROOT/scripts/node_modules/.bin/pm2" kill
+json_rpc stop
 # LCOV_EXCL_STOP


### PR DESCRIPTION
When the debugger attached to pm2, it would get disconnected unexpectedly.

I made the script wait for a debugger to attach because the python that depends on the json rpc would fail if you did not attach the debugger in time.

[/proc/net/tcp docs](https://www.kernel.org/doc/html/v5.8/networking/proc_net_tcp.html) 