### PR TITLE
Copy aws cli into final build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -347,6 +347,7 @@ COPY --from=build-python-stage \
     /usr/local/bin/fetch-update-meta \
     /usr/local/bin/patch-same-book-links \
     /usr/local/bin/link-rex \
+    /usr/local/bin/aws \
     /usr/local/bin/
 
 


### PR DESCRIPTION
Unfortunately, I did not catch this in the last PR. On the bright side, it is a simple fix and we found it prior to the next release 🎉. 