### PR TITLE
Move tex conversion

### DIFF
--- a/dockerfiles/steps/step-postbake.bash
+++ b/dockerfiles/steps/step-postbake.bash
@@ -1,6 +1,11 @@
 # Formerly git-bake-meta
 shopt -s globstar nullglob
 for collection in "$IO_BAKED/"*.baked.xhtml; do
+    if grep -E '.*data-math=.+?' "$collection" &> /dev/null; then
+        mathified="$collection.mathified.xhtml"
+        node "${JS_EXTRA_VARS[@]}" $MATHIFY_ROOT/typeset/start.js -i "$collection" -o "$mathified" -f mathml
+        mv "$mathified" "$collection"
+    fi
     slug_name=$(basename "$collection" | awk -F'[.]' '{ print $1; }')
     bake-meta "$IO_ASSEMBLE_META/$slug_name.assembled-metadata.json" "$IO_BAKED/$slug_name.baked.xhtml" "" "" "$IO_BAKE_META/$slug_name.baked-metadata.json"
 done

--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -116,12 +116,6 @@ while read -r line; do # Loop over each <book> entry in the META-INF/books.xml m
 
     ## download exercise images and replace internet links with local resource links
     download-exercise-images "$IO_RESOURCES" "temp-assembly/collection.assembled.xhtml" "$assembled_file"
-    
-    if grep -E '.*data-math=.+?' "$assembled_file" &> /dev/null; then
-        mathified="$assembled_file.mathified.xhtml"
-        node "${JS_EXTRA_VARS[@]}" $MATHIFY_ROOT/typeset/start.js -i "$assembled_file" -o "$mathified" -f mathml
-        mv "$mathified" "$assembled_file"
-    fi
 
     rm -rf temp-assembly
     rm "$IO_FETCH_META/modules/collection.xml"

--- a/nebuchadnezzar/requirements/main.txt
+++ b/nebuchadnezzar/requirements/main.txt
@@ -1,6 +1,5 @@
 lxml==4.9.2
 click>=7.1.2
-docker>=4.2.2
 pip
 requests>=2.24.0
 setuptools

--- a/test/test-step-02.bash
+++ b/test/test-step-02.bash
@@ -49,7 +49,7 @@ while read -r collection; do
         echo "ERROR: Could not find converted math"
         exit 1
     fi
-done < <(find $BOOK_DIR -name '*.baked.xhtml') 
+done < <(find $BOOK_DIR -name '*.linked.xhtml')
 
 # ################################
 # Clone a branch, 

--- a/test/test-step-02.bash
+++ b/test/test-step-02.bash
@@ -44,12 +44,12 @@ KCOV_DIR=_kcov02-d \
 find $BOOK_DIR -name "index.cnxml.orig" -exec bash -cxe 'mv $0 $(dirname $0)/index.cnxml' {} \;
 
 # Check that the math was converted
-while read -r assembled_file; do
-    if ! grep '<math xmlns="http://www.w3.org/1998/Math/MathML" alttext="\\frac{2}{5} + \\frac{10}{5}">' "$assembled_file" &> /dev/null; then
+while read -r collection; do
+    if ! grep '<math xmlns="http://www.w3.org/1998/Math/MathML" alttext="\\frac{2}{5} + \\frac{10}{5}">' "$collection" > /dev/null; then
         echo "ERROR: Could not find converted math"
         exit 1
     fi
-done < <(find $BOOK_DIR -name '*.assembled.xhtml') 
+done < <(find $BOOK_DIR -name '*.baked.xhtml') 
 
 # ################################
 # Clone a branch, 


### PR DESCRIPTION
related: openstax/cnx-recipes#5142

Something in cookbook causes namespaces to be moved up the tree. Converting TeX math before baking caused cookbook to move the MathML namespace to the math element's parent. This caused lists to break because `ol` and `li` do not mean anything within the MathML namespace.

It seemed like the simple solution was to move TeX math conversion so that it occurred immediately after baking. This fixes the issue in question and still ensures that we have no TeX math left by the time the build completes. Before and after images below.

## Before (conversion in prebake)
<img width="815" alt="Screen Shot 2023-06-02 at 10 39 28 AM" src="https://github.com/openstax/enki/assets/33585550/a330f646-dcbf-45cc-b85e-0d273dd77657">


## After (conversion in postbake)
<img width="815" alt="Screen Shot 2023-06-02 at 10 37 22 AM" src="https://github.com/openstax/enki/assets/33585550/1b5fd614-7713-4d38-bc7f-be3b9adde125">