### PR TITLE
S3 upload in chunks

### DIFF
--- a/bakery-src/scripts/copy_resources_s3.py
+++ b/bakery-src/scripts/copy_resources_s3.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 from pathlib import Path
+import math
 from .profiler import timed
 
 from timeit import default_timer as timer
@@ -13,8 +14,8 @@ import botocore
 
 # After research and benchmarking 64 seems to be the best speed without big
 # trade-offs.
-MAX_THREAD_CHECK_S3 = 64
-MAX_THREAD_UPLOAD_S3 = 64
+MAX_THREAD_CHECK_S3 = 32
+MAX_THREAD_UPLOAD_S3 = 32
 
 
 class EndOfStreamError(Exception):
@@ -65,6 +66,13 @@ async def map_async(func, it, worker_count, qsize=None):
         yield (result, err)
 
 
+def to_chunks(arr, chunk_size):
+    return [
+        arr[n * chunk_size : n * chunk_size + chunk_size]
+        for n in range(math.ceil(len(arr) / chunk_size))
+    ]
+
+
 def slash_join(*args):
     """ join url parts safely """
     return "/".join(arg.strip("/") for arg in args)
@@ -96,8 +104,8 @@ def is_s3_folder_empty(aws_key, aws_secret, aws_session_token, bucket, key):
 
 
 @timed
-def check_s3_existence(aws_key, aws_secret, aws_session_token, bucket, resource,
-                       disable_check=False):
+def check_s3_existence(aws_key, aws_secret, aws_session_token, bucket,
+                       resources, disable_check=False):
     """ check if resource is already existing or needs uploading """
 
     def s3_md5sum(s3_client, bucket_name, resource_name):
@@ -110,35 +118,42 @@ def check_s3_existence(aws_key, aws_secret, aws_session_token, bucket, resource,
         except botocore.exceptions.ClientError:  # pragma: no cover
             md5sum = None
         return md5sum
+    
+    def update_resource(resource, data):
+        resource['mime_type'] = data['mime_type']
+        resource['width'] = data['width']
+        resource['height'] = data['height']
+        return resource
 
-    try:
-        upload_resource = None
-        with open(resource['input_metadata_file']) as json_file:
-            data = json.load(json_file)
-        if disable_check:
-            # empty or non existing s3 folder
-            # skip individual s3 file check
-            upload_resource = resource
-        else:
-            session = boto3.session.Session()
-            s3_client = session.client(
-                's3',
-                aws_access_key_id=aws_key,
-                aws_secret_access_key=aws_secret,
-                aws_session_token=aws_session_token)
+    if disable_check:
+        check_resource = update_resource
+    else:
+        session = boto3.session.Session()
+        s3_client = session.client(
+            's3',
+            aws_access_key_id=aws_key,
+            aws_secret_access_key=aws_secret,
+            aws_session_token=aws_session_token)
+
+        def check_s3(resource, data):
             if data['s3_md5'] != s3_md5sum(s3_client, bucket,
                                            resource['output_s3']):
-                upload_resource = resource
+                return update_resource(resource, data)
+            else:
+                return None
 
-        if upload_resource is not None:
-            upload_resource['mime_type'] = data['mime_type']
-            upload_resource['width'] = data['width']
-            upload_resource['height'] = data['height']
+        check_resource = check_s3
 
-        return upload_resource
-    except FileNotFoundError as e:
-        print('Error: No metadata json found!')
-        raise (e)
+    checked_resources = []
+    for resource in resources:
+        try:
+            with open(resource['input_metadata_file']) as json_file:
+                data = json.load(json_file)
+            checked_resources.append(check_resource(resource, data))
+        except FileNotFoundError as e:
+            print('Error: No metadata json found!')
+            raise (e)
+    return checked_resources
 
 
 @timed
@@ -209,29 +224,32 @@ async def upload(in_dir, bucket, bucket_folder):
     start = timer()
     upload_resources = []
 
-    async def check_s3_existence_worker(resource):
+    async def check_s3_existence_worker(resources):
         return await asyncio.to_thread(
             check_s3_existence,
             aws_key=aws_key,
             aws_secret=aws_secret,
             aws_session_token=aws_session_token,
             bucket=bucket,
-            resource=resource,
+            resources=resources,
             disable_check=disable_deep_folder_check
         )
 
-    async for resource, err in map_async(
-        check_s3_existence_worker, all_resources, MAX_THREAD_CHECK_S3
+    async for checked_resources, err in map_async(
+        check_s3_existence_worker,
+        to_chunks(all_resources, 100),
+        MAX_THREAD_CHECK_S3
     ):
         if err is not None:
             raise err
-        if resource is not None:
-            upload_resources.append(resource)
-            if not disable_deep_folder_check:  # pragma: no cover
-                print(".", end="", flush=True)
-        else:
-            if not disable_deep_folder_check:  # pragma: no cover
-                print("x", end="", flush=True)
+        for maybe_resource in checked_resources:
+            if maybe_resource is not None:
+                upload_resources.append(maybe_resource)
+                if not disable_deep_folder_check:  # pragma: no cover
+                    print(".", end="", flush=True)
+            else:
+                if not disable_deep_folder_check:  # pragma: no cover
+                    print("x", end="", flush=True)
 
     if disable_deep_folder_check:
         print('- quick checked (destination S3 folder empty or non existing)',

--- a/bakery-src/scripts/copy_resources_s3.py
+++ b/bakery-src/scripts/copy_resources_s3.py
@@ -71,7 +71,7 @@ def to_chunks(it, chunk_size):
     a = []
     for item in it:
         a.append(item)
-        if len(a) == chunk_size:
+        if len(a) == chunk_size:  # pragma: no cover
             yield a
             a = []
     if a and len(a) < chunk_size:
@@ -144,7 +144,7 @@ def check_s3_existence(aws_key, aws_secret, aws_session_token, bucket,
             if data['s3_md5'] != s3_md5sum(s3_client, bucket,
                                            resource['output_s3']):
                 return update_resource(resource, data)
-            else:
+            else:  # pragma: no cover
                 return None
 
         check_resource = check_s3

--- a/bakery-src/scripts/copy_resources_s3.py
+++ b/bakery-src/scripts/copy_resources_s3.py
@@ -23,10 +23,7 @@ class EndOfStreamError(Exception):
     pass
 
 
-async def map_async(func, it, worker_count, qsize=None):
-    if qsize is None:
-        qsize = worker_count
-
+async def map_async(func, it, worker_count, qsize=0):
     in_queue, out_queue = asyncio.Queue(qsize), asyncio.Queue(qsize)
 
     async def feeder():

--- a/bakery-src/scripts/copy_resources_s3.py
+++ b/bakery-src/scripts/copy_resources_s3.py
@@ -71,7 +71,7 @@ def to_chunks(it, chunk_size):
         if len(a) == chunk_size:  # pragma: no cover
             yield a
             a = []
-    if a and len(a) < chunk_size:
+    if 0 < len(a) < chunk_size:
         yield a
 
 
@@ -105,7 +105,6 @@ def is_s3_folder_empty(aws_key, aws_secret, aws_session_token, bucket, key):
     return result
 
 
-@timed
 def check_s3_existence(aws_key, aws_secret, aws_session_token, bucket,
                        resources, disable_check=False):
     """ check if resource is already existing or needs uploading """
@@ -158,7 +157,6 @@ def check_s3_existence(aws_key, aws_secret, aws_session_token, bucket,
     return checked_resources
 
 
-@timed
 def upload_s3(aws_key, aws_secret, aws_session_token, bucket, resources):
     """ upload s3 process for ThreadPoolExecutor """
     # use session for multithreading according to

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -2214,9 +2214,9 @@ def test_s3_existence(tmp_path, mocker):
 
     upload_resource = copy_resources_s3.check_s3_existence(
         aws_key, aws_secret, aws_token,
-        bucket, test_resource,
+        bucket, [test_resource],
         disable_check=False
-    )
+    )[0]
 
     test_input_metadata = test_resource['input_metadata_file']
     test_output_s3 = test_resource['output_s3']
@@ -2255,7 +2255,7 @@ def test_s3_existence_404(tmp_path, mocker):
     with pytest.raises(FileNotFoundError):
         copy_resources_s3.check_s3_existence(
             aws_key, aws_secret, aws_token,
-            bucket, resource_for_test,
+            bucket, [resource_for_test],
             disable_check=False
         )
 
@@ -2375,11 +2375,11 @@ def test_s3_upload_async_error(tmp_path, mocker):
 
     def raise_exception(*args, **kwargs):
         raise MySuperSpecificTestException()
-    
+
     def mock_exists(*args, **kwargs):
         from collections import defaultdict
-        return defaultdict(str)
-    
+        return [defaultdict(str)] * len(kwargs["resources"])
+
     copy_resources_s3.check_s3_existence = mock_exists
     copy_resources_s3.upload_s3 = raise_exception
 
@@ -2443,8 +2443,8 @@ def test_async_feeder_error(tmp_path, mocker):
 
     def mock_exists(*args, **kwargs):
         # Return an empty dict to cause a key error
-        return {}
-    
+        return [{}]
+
     copy_resources_s3.check_s3_existence = mock_exists
 
     # The feeder should surface the key error that will happen in the


### PR DESCRIPTION
fixes openstax/ce#2078


<img width="1146" alt="Screen Shot 2023-06-22 at 3 05 39 PM" src="https://github.com/openstax/enki/assets/33585550/55347ce5-8a6c-403e-95f9-7b0bf95ae793">
(Yes, different commits, but both commits had the same number of images)

---

This started as an exploration, but the results were so dramatic that I thought I should make a PR. I guess creating a new session for each upload was taking quite a bit of time. The connection errors might have also been caused by creating one connection per resource.

Since we cannot safely share sessions/clients between threads, I made each thread process an array of inputs.

What happens when there is an error? While I was poking around at this, I ran into a key error because I forgot that metadata defaulted to `None` in the past. Since the worker surfaces any exceptions immediately after they occur, the entire upload process fails as expected:
<img width="1371" alt="Screen Shot 2023-06-22 at 3 16 23 PM" src="https://github.com/openstax/enki/assets/33585550/5026c937-77e4-44ff-9ea2-1f50a180f235">



