### PR TITLE
2094 upload fonts web

### DIFF
--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -30,9 +30,10 @@ fi
 
 
 # Copy web styles to the resources directory created by fetch-map-resources
-style_resource_root="initial-resources/styles"
+style_resource_root="$IO_INITIAL_RESOURCES/styles"
 generic_style="webview-generic.css"
 [[ ! -e "$style_resource_root" ]] && mkdir -p "$style_resource_root"
+cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$style_resource_root"
 while read -r slug_name; do
     style_name=$(read_style "$slug_name")
     web_style="$style_name-web.css"


### PR DESCRIPTION
fixes openstax/ce#2094

Right now, it appears that the `webview-generic.css` and `*-web.css` files are not being used. If we want them to work in the future, however, we will need to upload the fonts.

According to [This W3 draft](https://drafts.csswg.org/css-values-3/#example-b514611a), partial URLs are interpreted relative to the source of the style sheet, not relative to the document. Consequently, if the browser is responsible for importing the fonts, they should work if we use the same directory structure as in ce-styles repository.

This PR copies downloaded fonts into the style resource root and updates dependency checking to accept dependency that exist and will be uploaded. The style resource root directory (`IO_RESOURCES/styles`), and all of its subdirectories, are uploaded in `step-upload-book`.

The dependency check only checks imports in the `webview-generic.css` or `*-web.css` file. It does not check subsequent imports made in imported files (maybe it can in the future).