### PR TITLE
Update awscli to 1.29.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,10 +115,7 @@ RUN set -x \
 COPY ./nebuchadnezzar/requirements /workspace/enki/nebuchadnezzar/requirements
 COPY ./bakery-src/scripts/requirements.txt /workspace/enki/bakery-src/scripts/
 
-# More details: https://github.com/aws/aws-cli/issues/8036#issuecomment-1638544754
-# and: https://github.com/yaml/pyyaml/issues/601
-# PyYAML installed as dependency here [awscli](https://github.com/aws/aws-cli/blob/dbbf1ce01acec0116710968bbe5a96680e791c1b/setup.py#L30)
-RUN pip3 install "PyYAML==5.3.1" \
+RUN pip3 install \
     -r /workspace/enki/nebuchadnezzar/requirements/main.txt \
     -r /workspace/enki/bakery-src/scripts/requirements.txt
 

--- a/bakery-src/scripts/requirements.txt
+++ b/bakery-src/scripts/requirements.txt
@@ -1,5 +1,5 @@
 cnx-common==1.3.6
-awscli==1.27.133
+awscli==1.29.25
 boto3>=1.12.48
 urllib3<1.27,>=1.25.4
 imagesize==1.4.1


### PR DESCRIPTION
The PyYAML pin was added as a workaround to a cython issue that affected versions (5.3.1, 6.0.0] of PyYAML. This newer version of the aws cli supports version 6.0.1 of PyYAML. Consequently, this update makes the PyYAML workaround unnecessary.

I looked into upgrading to v2 of the aws cli as well; however, while you can upgrade and use that version (see v2 branch of the repo), it is still under development.