### PR TITLE
ignore all anchor tags without href, they are still valid html

### DIFF
--- a/bakery-js/src/epub/page.test.ts
+++ b/bakery-js/src/epub/page.test.ts
@@ -42,6 +42,7 @@ describe('Pages', () => {
         <math xmlns="http://www.w3.org/1998/Math/MathML" />
         <iframe/>
         <a href="./${otherPageFilename}"/>
+        <a id="this-is-valid-html"/>
       </body>
     </html>`
 

--- a/bakery-js/src/epub/page.tsx
+++ b/bakery-js/src/epub/page.tsx
@@ -31,7 +31,7 @@ function filterNulls<T>(l: Array<T | null>): Array<T> {
 }
 
 const pageLinkXpath =
-  '//h:a[not(starts-with(@href, "http:") or starts-with(@href, "https:") or starts-with(@href, "#"))]'
+  '//h:a[@href and not(starts-with(@href, "http:") or starts-with(@href, "https:") or starts-with(@href, "#"))]'
 
 export class PageFile extends XmlFile<
   PageData,


### PR DESCRIPTION
`<a id="1">..</a>` tags without `href` are still valid HTML. They are like real "anchors" or like "bookmarks" to be jumped to by id.