### PR TITLE
Update process for installing node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,14 +54,20 @@ RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pando
 # ---------------------------
 FROM base as base-with-langs
 ENV NODE_VERSION=18
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 RUN set -x \
     && apt-get update \
+    && apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+        gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | \
+        tee /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
     && apt-get install --no-install-recommends -y \
-    openjdk-11-jre-headless \
-    python3 \
-    python3-pip \
-    nodejs \
+        openjdk-11-jre-headless \
+        python3 \
+        python3-pip \
+        nodejs \
     ;
 
 


### PR DESCRIPTION
There was a deprecation warning with a timeout.

[Here](https://github.com/nodesource/distributions#nodejs) you can find more details about this change.