### PR TITLE
2114 - Neb book containter parsing

### DIFF
--- a/nebuchadnezzar/nebu/cli/assemble.py
+++ b/nebuchadnezzar/nebu/cli/assemble.py
@@ -88,7 +88,7 @@ def assemble(ctx, input_dir, output_dir, exercise_token, exercise_host):
     output_dir = Path(output_dir)
     if not output_dir.exists():
         output_dir.mkdir()
-    
+
     for book in container.books:
         output_assembled_xhtml = output_dir / f"{book.slug}.assembled.xhtml"
 

--- a/nebuchadnezzar/nebu/cli/assemble.py
+++ b/nebuchadnezzar/nebu/cli/assemble.py
@@ -12,6 +12,8 @@ from ..formatters import (
     exercise_callback_factory,
 )
 from ..xml_utils import fix_namespaces
+from ..models.book_container import BookContainer
+from ..models.path_resolver import PathResolver
 
 
 ASSEMBLED_FILENAME = "collection.assembled.xhtml"
@@ -40,14 +42,14 @@ def create_exercise_factories(exercise_host, token):
 
 
 def collection_to_assembled_xhtml(
-    collection, docs_by_id, docs_by_uuid, input_dir, token, exercise_host
+    collection, docs_by_id, docs_by_uuid, path_resolver, token, exercise_host
 ):
     page_uuids = list(docs_by_uuid.keys())
     includes = create_exercise_factories(exercise_host, token)
     # Use docs_by_uuid.values to ensure each document is only used one time
     for document in docs_by_uuid.values():
         # Step 1: Rewrite module links
-        resolve_module_links(document, docs_by_id, input_dir)
+        resolve_module_links(document, docs_by_id, path_resolver)
         # Step 2: Update ids and links
         update_ids(document)
 
@@ -80,32 +82,31 @@ def assemble(ctx, input_dir, output_dir, exercise_token, exercise_host):
     assembled single-page-html.
 
     """
-    input_dir = Path(input_dir)
+    books_xml = Path(input_dir) / "META-INF" / "books.xml"
+    container = BookContainer.from_str(books_xml.read_text(), input_dir)
+    path_resolver = PathResolver(container)
     output_dir = Path(output_dir)
-    output_assembled_xhtml = output_dir / ASSEMBLED_FILENAME
-
-    if output_assembled_xhtml.exists():
-        confirm_msg = (
-            "File '{}' already exists. Would you like to replace it?".format(
-                output_assembled_xhtml
-            )
-        )
-        click.confirm(confirm_msg, abort=True, err=True)
-        output_assembled_xhtml.unlink()
     if not output_dir.exists():
         output_dir.mkdir()
+    
+    for book in container.books:
+        output_assembled_xhtml = output_dir / f"{book.slug}.assembled.xhtml"
 
-    collection, docs_by_id, docs_by_uuid = BookPart.collection_from_file(
-        input_dir / "collection.xml"
-    )
-    assembled_xhtml = collection_to_assembled_xhtml(
-        collection,
-        docs_by_id,
-        docs_by_uuid,
-        input_dir,
-        exercise_token,
-        exercise_host,
-    )
-    output_assembled_xhtml.write_bytes(assembled_xhtml)
+        assert not output_assembled_xhtml.exists(), \
+            f'File "{output_assembled_xhtml}" already exists.'
+
+        collection, docs_by_id, docs_by_uuid = BookPart.collection_from_file(
+            path_resolver.get_collection_path(book.slug),
+            path_resolver
+        )
+        assembled_xhtml = collection_to_assembled_xhtml(
+            collection,
+            docs_by_id,
+            docs_by_uuid,
+            path_resolver,
+            exercise_token,
+            exercise_host,
+        )
+        output_assembled_xhtml.write_bytes(assembled_xhtml)
 
     return 0

--- a/nebuchadnezzar/nebu/formatters.py
+++ b/nebuchadnezzar/nebu/formatters.py
@@ -86,13 +86,13 @@ def update_ids(document):
 
 
 @lru_cache(maxsize=None)
-def _get_external_document(input_dir, module_id):
+def _get_external_document(p):
     from .models.book_part import BookPart
 
-    return BookPart.doc_from_file(input_dir, module_id)
+    return BookPart.doc_from_file(p)
 
 
-def resolve_module_links(document, docs_by_id, input_dir):
+def resolve_module_links(document, docs_by_id, path_resolver):
     """Resolve module links
     <a href="/contents/{PAGE_ID} (and maybe fragment?)"> (other-book link)
     <a href="#page_{PAGE_ID}"> (same-book link)
@@ -117,7 +117,9 @@ def resolve_module_links(document, docs_by_id, input_dir):
         if target_document is not None:
             new_href = fmt_str.format(target_document.metadata["uuid"])
         else:
-            target_document = _get_external_document(input_dir, module_id)
+            target_document = _get_external_document(
+                path_resolver.get_module_path(module_id)
+            )
             uuid = target_document.metadata["uuid"]
             new_href = f"/contents{href.replace(module_id, uuid)}"
         link.set("href", new_href)

--- a/nebuchadnezzar/nebu/models/book_container.py
+++ b/nebuchadnezzar/nebu/models/book_container.py
@@ -34,8 +34,9 @@ def parse_books(etree):
             )
             if v is not None
         }
-        assert all(v != "" for v in kwargs.values()), \
-            "Missing required value for book"
+        assert all(
+            v != "" for v in kwargs.values()
+        ), "Missing required value for book"
         books.append(Book(**kwargs))
     return books
 
@@ -82,7 +83,7 @@ def book_container_factory(
                 books=parse_books(etree),
                 **parse_book_vars(etree)
             )
-    
+
     return BookContainer
 
 

--- a/nebuchadnezzar/nebu/models/book_container.py
+++ b/nebuchadnezzar/nebu/models/book_container.py
@@ -59,20 +59,23 @@ def book_container_factory(
         public_root: str = default_public_root
 
         def __post_init__(self):
+            # NOTE: Using os.path.join here will create invalid paths.
+            # The paths in the book vars are absolute relative to the repo root
+            # but joining with os.path.join will make it absolute relative to /
             self.books_root = os.path.realpath(
-                f"{self.root_dir}/{self.books_root}"
+                os.sep.join((self.root_dir, self.books_root))
             )
             self.pages_root = os.path.realpath(
-                f"{self.root_dir}/{self.pages_root}"
+                os.sep.join((self.root_dir, self.pages_root))
             )
             self.media_root = os.path.realpath(
-                f"{self.root_dir}/{self.media_root}"
+                os.sep.join((self.root_dir, self.media_root))
             )
             self.private_root = os.path.realpath(
-                f"{self.root_dir}/{self.private_root}"
+                os.sep.join((self.root_dir, self.private_root))
             )
             self.public_root = os.path.realpath(
-                f"{self.root_dir}/{self.public_root}"
+                os.sep.join((self.root_dir, self.public_root))
             )
 
         @classmethod

--- a/nebuchadnezzar/nebu/models/book_container.py
+++ b/nebuchadnezzar/nebu/models/book_container.py
@@ -1,0 +1,103 @@
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ..xml_utils import etree_from_str
+
+
+CONTAINER_NSMAP = {
+    "bk": "https://openstax.org/namespaces/book-container",
+}
+
+
+def parse_book_vars(etree):
+    bk_vars = etree.xpath("//bk:var", namespaces=CONTAINER_NSMAP)
+    bk_vars_by_name = {}
+
+    for el in bk_vars:
+        name = el.attrib["name"].strip()
+        value = el.attrib["value"].strip()
+        assert name, "Expected book var name, got empty string"
+        assert value, "Expected book var value, got empty string"
+        bk_vars_by_name[name.lower()] = value
+    return bk_vars_by_name
+
+
+def parse_books(etree):
+    books = []
+    for book in etree.xpath("//bk:book", namespaces=CONTAINER_NSMAP):
+        kwargs = {
+            k: v.strip()
+            for k, v in (
+                (k, book.attrib.get(k.replace("_", "-"), None))
+                for k in Book.__dataclass_fields__.keys()
+            )
+            if v is not None
+        }
+        assert all(v != "" for v in kwargs.values()), \
+            "Missing required value for book"
+        books.append(Book(**kwargs))
+    return books
+
+
+def book_container_factory(
+    default_books_root: str,
+    default_pages_root: str,
+    default_media_root: str,
+    default_private_root: str,
+    default_public_root: str,
+):
+    @dataclass
+    class BookContainer:
+        root_dir: str
+        books: List["Book"]
+        books_root: str = default_books_root
+        pages_root: str = default_pages_root
+        media_root: str = default_media_root
+        private_root: str = default_private_root
+        public_root: str = default_public_root
+
+        def __post_init__(self):
+            self.books_root = os.path.realpath(
+                f"{self.root_dir}/{self.books_root}"
+            )
+            self.pages_root = os.path.realpath(
+                f"{self.root_dir}/{self.pages_root}"
+            )
+            self.media_root = os.path.realpath(
+                f"{self.root_dir}/{self.media_root}"
+            )
+            self.private_root = os.path.realpath(
+                f"{self.root_dir}/{self.private_root}"
+            )
+            self.public_root = os.path.realpath(
+                f"{self.root_dir}/{self.public_root}"
+            )
+
+        @classmethod
+        def from_str(cls, xml_str: str, root_dir: str):
+            etree = etree_from_str(xml_str)
+            return cls(
+                root_dir=root_dir,
+                books=parse_books(etree),
+                **parse_book_vars(etree)
+            )
+    
+    return BookContainer
+
+
+@dataclass
+class Book:
+    slug: str
+    style: str
+    href: str
+    collection_id: Optional[str] = None
+
+
+BookContainer = book_container_factory(
+    "/collections",
+    "/modules",
+    "/media",
+    "/private",
+    "/interactives",
+)

--- a/nebuchadnezzar/nebu/models/book_part.py
+++ b/nebuchadnezzar/nebu/models/book_part.py
@@ -58,15 +58,15 @@ class BookPart:
                 yield book_part
 
     @staticmethod
-    def doc_from_file(input_dir, id):
-        cnxml = open_xml(str(input_dir / id / "index.cnxml"))
+    def doc_from_file(p):
+        cnxml = open_xml(p)
         metadata = parse_metadata(cnxml)
         html = etree_from_str(etree_cnxml_to_full_html(cnxml).encode())
         doc = BookPart(PartType.DOCUMENT, metadata, html)
         return doc
 
     @staticmethod
-    def collection_from_file(filepath):
+    def collection_from_file(filepath, path_resolver):
         """\
         Given a ``collection.xml`` as ``filepath``.
 
@@ -89,12 +89,12 @@ class BookPart:
             return BookPart(PartType.SUBCOL, {})
 
         def new_doc(id):
-            doc = BookPart.doc_from_file(filepath.parent, id)
+            doc = BookPart.doc_from_file(path_resolver.get_module_path(id))
             doc_by_id[id] = doc_by_uuid[doc.metadata["uuid"]] = doc
             return doc
 
         # Obtain metadata about the collection
-        with filepath.open("rb") as fb:
+        with open(filepath, "rb") as fb:
             xml = open_xml(fb)
 
         root_part = parent_part = current_part = new_col()

--- a/nebuchadnezzar/nebu/models/path_resolver.py
+++ b/nebuchadnezzar/nebu/models/path_resolver.py
@@ -1,0 +1,50 @@
+import os
+import re
+from pathlib import Path
+from typing import Callable, Union, Iterable
+
+from .book_container import BookContainer
+
+
+def _search_path(p, pattern):
+    match = re.search(pattern, str(p))
+    assert match is not None, f'"{pattern}" not found in "{p}"'
+    return match
+
+
+def path_resolver_factory(
+    module_path_getter: Callable[[BookContainer], Iterable[Union[Path, str]]], 
+    module_id_pattern: str
+):
+    class PathResolver:
+        def __init__(self, book_container: BookContainer):
+            self._collection_paths_by_book = {
+                book.slug: os.path.realpath(
+                    os.path.join(
+                        book_container.root_dir,
+                        os.path.relpath(
+                            book_container.books_root,
+                            book_container.root_dir
+                        ),
+                        os.path.basename(book.href),
+                    )
+                )
+                for book in book_container.books
+            }
+            self._module_paths_by_id = {
+                _search_path(p, module_id_pattern).group(0): str(p)
+                for p in module_path_getter(book_container)
+            }
+        
+        def get_collection_path(self, book_slug: str) -> str:
+            return self._collection_paths_by_book[book_slug]
+        
+        def get_module_path(self, module_id: str) -> str:
+            return self._module_paths_by_id[module_id]
+
+    return PathResolver
+
+
+PathResolver = path_resolver_factory(
+    lambda container: Path(container.pages_root).glob('**/*.cnxml'), r'm[0-9]+'
+)

--- a/nebuchadnezzar/nebu/models/path_resolver.py
+++ b/nebuchadnezzar/nebu/models/path_resolver.py
@@ -13,7 +13,7 @@ def _search_path(p, pattern):
 
 
 def path_resolver_factory(
-    module_path_getter: Callable[[BookContainer], Iterable[Union[Path, str]]], 
+    module_path_getter: Callable[[BookContainer], Iterable[Union[Path, str]]],
     module_id_pattern: str
 ):
     class PathResolver:
@@ -35,10 +35,10 @@ def path_resolver_factory(
                 _search_path(p, module_id_pattern).group(0): str(p)
                 for p in module_path_getter(book_container)
             }
-        
+
         def get_collection_path(self, book_slug: str) -> str:
             return self._collection_paths_by_book[book_slug]
-        
+
         def get_module_path(self, module_id: str) -> str:
             return self._module_paths_by_id[module_id]
 

--- a/nebuchadnezzar/nebu/models/path_resolver.py
+++ b/nebuchadnezzar/nebu/models/path_resolver.py
@@ -1,20 +1,20 @@
 import os
 import re
 from pathlib import Path
-from typing import Callable, Union, Iterable
+from typing import Callable, Union, Iterable, Optional
+from functools import partial
 
 from .book_container import BookContainer
 
 
-def _search_path(p, pattern):
-    match = re.search(pattern, str(p))
-    assert match is not None, f'"{pattern}" not found in "{p}"'
-    return match
+def _first_or_none(pattern: str, s: str) -> Optional[str]:
+    match = re.search(pattern, str(s))
+    return match.group(0) if match is not None else None
 
 
 def path_resolver_factory(
     module_path_getter: Callable[[BookContainer], Iterable[Union[Path, str]]],
-    module_id_pattern: str,
+    module_id_getter: Callable[[str], Optional[str]],
 ):
     class PathResolver:
         def __init__(self, book_container: BookContainer):
@@ -27,8 +27,12 @@ def path_resolver_factory(
                 for book in book_container.books
             }
             self._module_paths_by_id = {
-                _search_path(p, module_id_pattern).group(0): str(p)
-                for p in module_path_getter(book_container)
+                module_id: p
+                for module_id, p in (
+                    (module_id_getter(p), p)
+                    for p in map(str, module_path_getter(book_container))
+                )
+                if module_id is not None
             }
 
         def get_collection_path(self, book_slug: str) -> str:
@@ -41,5 +45,6 @@ def path_resolver_factory(
 
 
 PathResolver = path_resolver_factory(
-    lambda container: Path(container.pages_root).glob("**/*.cnxml"), r"m[0-9]+"
+    lambda container: Path(container.pages_root).glob("**/*.cnxml"),
+    partial(_first_or_none, r"m[0-9]+")
 )

--- a/nebuchadnezzar/nebu/models/path_resolver.py
+++ b/nebuchadnezzar/nebu/models/path_resolver.py
@@ -14,19 +14,14 @@ def _search_path(p, pattern):
 
 def path_resolver_factory(
     module_path_getter: Callable[[BookContainer], Iterable[Union[Path, str]]],
-    module_id_pattern: str
+    module_id_pattern: str,
 ):
     class PathResolver:
         def __init__(self, book_container: BookContainer):
             self._collection_paths_by_book = {
                 book.slug: os.path.realpath(
                     os.path.join(
-                        book_container.root_dir,
-                        os.path.relpath(
-                            book_container.books_root,
-                            book_container.root_dir
-                        ),
-                        os.path.basename(book.href),
+                        book_container.books_root, os.path.basename(book.href)
                     )
                 )
                 for book in book_container.books
@@ -46,5 +41,5 @@ def path_resolver_factory(
 
 
 PathResolver = path_resolver_factory(
-    lambda container: Path(container.pages_root).glob('**/*.cnxml'), r'm[0-9]+'
+    lambda container: Path(container.pages_root).glob("**/*.cnxml"), r"m[0-9]+"
 )

--- a/nebuchadnezzar/nebu/tests/cli/test_assemble.py
+++ b/nebuchadnezzar/nebu/tests/cli/test_assemble.py
@@ -123,42 +123,6 @@ class TestAssembleCmd:
         # Verify the invocation output
         assert result.exit_code == 0, result.output
 
-    def test_output_files_exists_proceed(self, tmp_path, src_data, invoker):
-        output_dir = tmp_path / "build"
-        output_dir.mkdir()
-        (output_dir / "collection.assembled.xhtml").touch()
-
-        from nebu.cli.main import cli
-
-        args = [
-            "assemble",  # (target)
-            str(src_data),
-            str(output_dir),
-        ]
-        # This asks to replace the collection.assembled.xhtml file
-        result = invoker(cli, args, input="y\n")  # 'y', proceed with removal
-
-        # Verify the invocation output
-        assert result.exit_code == 0, result.output
-
-    def test_output_file_exists_abort(self, tmp_path, src_data, invoker):
-        output_dir = tmp_path / "build"
-        output_dir.mkdir()
-        (output_dir / "collection.assembled.xhtml").touch()
-
-        from nebu.cli.main import cli
-
-        args = [
-            "assemble",  # (target)
-            str(src_data),
-            str(output_dir),
-        ]
-        result = invoker(cli, args, input="\n")  # accept default: 'N'
-
-        # Verify the invocation output
-        assert result.exit_code == 1, result.output
-        assert "Aborted!" in result.output
-
     def test_edited_collection_xml(
         self, tmp_path, src_data, invoker, edit_collection_xml
     ):
@@ -233,7 +197,7 @@ def current_snapshot_dir(snapshot_dir):
 
 
 @pytest.fixture
-def assembled_pair(parts_tuple, exercise_mock, git_collection_data):
+def assembled_pair(parts_tuple, exercise_mock, git_path_resolver):
     from nebu.cli.assemble import collection_to_assembled_xhtml
 
     collection, docs_by_id, docs_by_uuid = parts_tuple
@@ -241,7 +205,7 @@ def assembled_pair(parts_tuple, exercise_mock, git_collection_data):
         collection,
         docs_by_id,
         docs_by_uuid,
-        git_collection_data,
+        git_path_resolver,
         None,
         "exercises.openstax.org"
     )

--- a/nebuchadnezzar/nebu/tests/conftest.py
+++ b/nebuchadnezzar/nebu/tests/conftest.py
@@ -17,10 +17,29 @@ def git_collection_data(datadir):
 
 
 @pytest.fixture
-def parts_tuple(git_collection_data):
+def git_collection_container(git_collection_data):
+    from nebu.models.book_container import BookContainer
+    
+    return BookContainer.from_str(
+        (git_collection_data / "META-INF" / "books.xml").read_text(),
+        str(git_collection_data)
+    )
+
+
+@pytest.fixture
+def git_path_resolver(git_collection_container):
+    from nebu.models.path_resolver import PathResolver
+    
+    return PathResolver(git_collection_container)
+
+
+@pytest.fixture
+def parts_tuple(git_collection_data, git_path_resolver):
     from nebu.models.book_part import BookPart
+
     collection, docs_by_id, docs_by_uuid = BookPart.collection_from_file(
-        git_collection_data / "collection.xml"
+        git_path_resolver.get_collection_path("collection"),
+        git_path_resolver
     )
     return (collection, docs_by_id, docs_by_uuid)
 

--- a/nebuchadnezzar/nebu/tests/conftest.py
+++ b/nebuchadnezzar/nebu/tests/conftest.py
@@ -19,7 +19,7 @@ def git_collection_data(datadir):
 @pytest.fixture
 def git_collection_container(git_collection_data):
     from nebu.models.book_container import BookContainer
-    
+
     return BookContainer.from_str(
         (git_collection_data / "META-INF" / "books.xml").read_text(),
         str(git_collection_data)
@@ -29,7 +29,7 @@ def git_collection_container(git_collection_data):
 @pytest.fixture
 def git_path_resolver(git_collection_container):
     from nebu.models.path_resolver import PathResolver
-    
+
     return PathResolver(git_collection_container)
 
 

--- a/nebuchadnezzar/nebu/tests/data/collection_for_git_workflow/META-INF/books.xml
+++ b/nebuchadnezzar/nebu/tests/data/collection_for_git_workflow/META-INF/books.xml
@@ -1,0 +1,5 @@
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <book slug="collection" style="dummy" href="collection.xml" />
+    <var name="BOOKS_ROOT" value="/" />
+    <var name="PAGES_ROOT" value="/" />
+</container>

--- a/nebuchadnezzar/nebu/tests/models/test_book_container.py
+++ b/nebuchadnezzar/nebu/tests/models/test_book_container.py
@@ -1,6 +1,5 @@
 import os
 
-import pytest
 from nebu.models.book_container import (
     book_container_factory,
     parse_book_vars,
@@ -97,16 +96,16 @@ def test_partial_container():
 """
     container = BookContainer.from_str(books_xml, ".")
     # Updated
-    assert container.books_root.endswith("/books") 
+    assert container.books_root.endswith("/books")
     assert os.path.isabs(container.books_root)
     # Stay the same
-    assert container.pages_root.endswith("/modules") 
+    assert container.pages_root.endswith("/modules")
     assert os.path.isabs(container.pages_root)
-    assert container.media_root.endswith("/media") 
+    assert container.media_root.endswith("/media")
     assert os.path.isabs(container.media_root)
-    assert container.private_root.endswith("/private") 
+    assert container.private_root.endswith("/private")
     assert os.path.isabs(container.private_root)
-    assert container.public_root.endswith("/interactives") 
+    assert container.public_root.endswith("/interactives")
     assert os.path.isabs(container.public_root)
 
 
@@ -121,5 +120,5 @@ def test_invalid_var_name():
         _ = BookContainer.from_str(books_xml, ".")
     except Exception as e:
         exc = str(e)
-    assert "unexpected keyword argument" in exc 
+    assert "unexpected keyword argument" in exc
     assert "test_invalid_name" in exc

--- a/nebuchadnezzar/nebu/tests/models/test_book_container.py
+++ b/nebuchadnezzar/nebu/tests/models/test_book_container.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from nebu.models.book_container import (
     book_container_factory,
     parse_book_vars,
@@ -79,12 +80,10 @@ def test_parse_books_missing_required():
 </container>
 """
     etree = etree_from_str(books_xml)
-    exc = ""
-    try:
+    with pytest.raises(Exception) as exc:
         _ = parse_books(etree)
-    except Exception as e:
-        exc = str(e)
-    assert "missing 1 required positional argument" in exc and "style" in exc
+    assert "missing 1 required positional argument" in str(exc)
+    assert "style" in str(exc)
 
 
 def test_partial_container():
@@ -115,10 +114,7 @@ def test_invalid_var_name():
     <var name="TEST_INVALID_NAME" value="..." />
 </container>
 """
-    exc = ""
-    try:
+    with pytest.raises(Exception) as exc:
         _ = BookContainer.from_str(books_xml, ".")
-    except Exception as e:
-        exc = str(e)
-    assert "unexpected keyword argument" in exc
-    assert "test_invalid_name" in exc
+    assert "unexpected keyword argument" in str(exc)
+    assert "test_invalid_name" in str(exc)

--- a/nebuchadnezzar/nebu/tests/models/test_book_container.py
+++ b/nebuchadnezzar/nebu/tests/models/test_book_container.py
@@ -1,0 +1,125 @@
+import os
+
+import pytest
+from nebu.models.book_container import (
+    book_container_factory,
+    parse_book_vars,
+    parse_books,
+)
+from nebu.xml_utils import etree_from_str
+
+
+BookContainer = book_container_factory(
+    "/collections",
+    "/modules",
+    "/media",
+    "/private",
+    "/interactives",
+)
+
+
+def test_default_container_values():
+    container = BookContainer(".", [])
+    assert container.books_root.endswith("/collections")
+    assert os.path.isabs(container.books_root)
+    assert container.pages_root.endswith("/modules")
+    assert os.path.isabs(container.pages_root)
+    assert container.media_root.endswith("/media")
+    assert os.path.isabs(container.media_root)
+    assert container.private_root.endswith("/private")
+    assert os.path.isabs(container.private_root)
+    assert container.public_root.endswith("/interactives")
+    assert os.path.isabs(container.public_root)
+
+
+def test_parse_book_vars():
+    books_xml = """\
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <var name="BOOKS_ROOT" value="/books" />
+</container>
+"""
+    etree = etree_from_str(books_xml)
+    book_vars = parse_book_vars(etree)
+    assert book_vars["books_root"] == "/books"
+
+
+def test_parse_books():
+    books_xml = """\
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <book slug="slug_name" style="dummy" href="href_path" />
+</container>
+"""
+    etree = etree_from_str(books_xml)
+    books = parse_books(etree)
+    book = books[0]
+    assert book.slug == "slug_name"
+    assert book.style == "dummy"
+    assert book.href == "href_path"
+    assert book.collection_id is None
+
+
+def test_parse_books_collection_id():
+    books_xml = """\
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <book slug="slug_name" style="dummy" collection-id="col12345" href="href_path" />
+</container>
+"""
+    etree = etree_from_str(books_xml)
+    books = parse_books(etree)
+    book = books[0]
+    assert book.slug == "slug_name"
+    assert book.style == "dummy"
+    assert book.href == "href_path"
+    assert book.collection_id == "col12345"
+
+
+def test_parse_books_missing_required():
+    books_xml = """\
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <book slug="slug_name" href="href_path" />
+</container>
+"""
+    etree = etree_from_str(books_xml)
+    exc = ""
+    try:
+        _ = parse_books(etree)
+    except Exception as e:
+        exc = str(e)
+    assert "missing 1 required positional argument" in exc and "style" in exc
+
+
+def test_partial_container():
+    books_xml = """\
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <var name="BOOKS_ROOT" value="/books" />
+    <book slug="slug_name" href="href_path" style="dummy" />
+</container>
+"""
+    container = BookContainer.from_str(books_xml, ".")
+    # Updated
+    assert container.books_root.endswith("/books") 
+    assert os.path.isabs(container.books_root)
+    # Stay the same
+    assert container.pages_root.endswith("/modules") 
+    assert os.path.isabs(container.pages_root)
+    assert container.media_root.endswith("/media") 
+    assert os.path.isabs(container.media_root)
+    assert container.private_root.endswith("/private") 
+    assert os.path.isabs(container.private_root)
+    assert container.public_root.endswith("/interactives") 
+    assert os.path.isabs(container.public_root)
+
+
+def test_invalid_var_name():
+    books_xml = """\
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <var name="TEST_INVALID_NAME" value="..." />
+</container>
+"""
+    exc = ""
+    try:
+        _ = BookContainer.from_str(books_xml, ".")
+    except Exception as e:
+        exc = str(e)
+    assert "unexpected keyword argument" in exc 
+    assert "test_invalid_name" in exc

--- a/nebuchadnezzar/nebu/tests/models/test_book_part.py
+++ b/nebuchadnezzar/nebu/tests/models/test_book_part.py
@@ -10,10 +10,8 @@ def current_snapshot_dir(snapshot_dir):
     return snapshot_dir / "test_book_part"
 
 
-def test_collection_from_file(assert_match, git_collection_data):
-    collection, docs_by_id, docs_by_uuid = BookPart.collection_from_file(
-        git_collection_data / "collection.xml"
-    )
+def test_collection_from_file(assert_match, parts_tuple):
+    collection, docs_by_id, docs_by_uuid = parts_tuple
 
     def part_to_dict(book_part):
         return dict(

--- a/nebuchadnezzar/nebu/tests/models/test_book_part.py
+++ b/nebuchadnezzar/nebu/tests/models/test_book_part.py
@@ -1,7 +1,6 @@
 import json
 
 import pytest
-from nebu.models.book_part import BookPart
 from nebu.xml_utils import etree_to_str
 
 

--- a/nebuchadnezzar/nebu/tests/models/test_path_resolver.py
+++ b/nebuchadnezzar/nebu/tests/models/test_path_resolver.py
@@ -1,8 +1,17 @@
 import os
+import re
+from functools import partial
+from typing import Optional
 
 from nebu.models.path_resolver import path_resolver_factory
 from nebu.models.book_container import book_container_factory, Book
 import pytest
+
+
+def _first_or_none(pattern: str, s: str) -> Optional[str]:
+    match = re.search(pattern, str(s))
+    return match.group(0) if match is not None else None
+
 
 BookContainer = book_container_factory(
     "/collections",
@@ -19,7 +28,8 @@ module_id_map = {
 }
 
 PathResolver = path_resolver_factory(
-    lambda _: ["a/b/c/m1234", "a/b/c/m4567", "a/b/c/m8910"], r"m[0-9]+"
+    lambda _: ["a/b/c/m1234", "a/b/c/m4567", "a/b/c/m8910"],
+    partial(_first_or_none, r"m[0-9]+")
 )
 
 

--- a/nebuchadnezzar/nebu/tests/models/test_path_resolver.py
+++ b/nebuchadnezzar/nebu/tests/models/test_path_resolver.py
@@ -1,0 +1,58 @@
+import os
+
+from nebu.models.path_resolver import path_resolver_factory
+from nebu.models.book_container import book_container_factory, Book
+import pytest
+
+BookContainer = book_container_factory(
+    "/collections",
+    "/modules",
+    "/media",
+    "/private",
+    "/interactives",
+)
+
+module_id_map = {
+    "m1234": "a/b/c/m1234",
+    "m4567": "a/b/c/m4567",
+    "m8910": "a/b/c/m8910",
+}
+
+PathResolver = path_resolver_factory(
+    lambda _: ["a/b/c/m1234", "a/b/c/m4567", "a/b/c/m8910"], r"m[0-9]+"
+)
+
+
+@pytest.fixture
+def test_collection_href():
+    return "../collections/test.collection.xml"
+
+
+@pytest.fixture
+def test_container(test_collection_href):
+    return BookContainer(
+        "/made/up/abs/path",
+        [
+            Book(
+                "book-slug1", "dummy", test_collection_href
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def test_resolver(test_container):
+    return PathResolver(test_container)
+
+
+def test_resolve_module_id(test_resolver):
+    for k, v in module_id_map.items():
+        assert test_resolver.get_module_path(k) == v
+
+
+def test_resolve_book_slug(test_container, test_resolver, test_collection_href):
+    p = test_resolver.get_collection_path("book-slug1")
+    assert p == os.path.join(
+        test_container.books_root,
+        os.path.basename(test_collection_href)
+    )


### PR DESCRIPTION
refs openstax/ce#2114

This change cuts many assumptions made about where documents are located. The goal is the make the only assumed path be `<repo-root>/META-INF/books.xml`. Currently, this is designed with the assumption that the path variables in the books xml, if given, are specified as absolute paths relative to the given root directory (the book repository in most cases).

For example, I added a new [books.xml](https://github.com/openstax/enki/compare/neb-book-containter?expand=1#diff-cbb129bcd2388f034f8c8597f6b7d9d8ed849d9ca9e72522ac32e65e2f1c61e6) to the test data that specifies that the pages and the books are in `/`. Since `/` is relative to the book repository root, those paths resolve to `nebuchadnezzar/nebu/tests/data/collection_for_git_workflow` because that directory was specified as the root directory when the book container was created.