### PR TITLE
Books xml encoding

### DIFF
--- a/nebuchadnezzar/nebu/cli/assemble.py
+++ b/nebuchadnezzar/nebu/cli/assemble.py
@@ -17,7 +17,6 @@ from ..models.book_container import BookContainer
 from ..models.path_resolver import PathResolver
 
 
-ASSEMBLED_FILENAME = "collection.assembled.xhtml"
 DEFAULT_EXERCISES_HOST = "exercises.openstax.org"
 
 
@@ -84,7 +83,7 @@ def assemble(ctx, input_dir, output_dir, exercise_token, exercise_host):
 
     """
     books_xml = Path(input_dir) / "META-INF" / "books.xml"
-    container = BookContainer.from_str(books_xml.read_text(), input_dir)
+    container = BookContainer.from_str(books_xml.read_bytes(), input_dir)
     path_resolver = PathResolver(
         container,
         lambda container: Path(container.pages_root).glob("**/*.cnxml"),

--- a/nebuchadnezzar/nebu/models/book_container.py
+++ b/nebuchadnezzar/nebu/models/book_container.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from ..xml_utils import etree_from_str
 
@@ -79,7 +79,7 @@ def book_container_factory(
             )
 
         @classmethod
-        def from_str(cls, xml_str: str, root_dir: str):
+        def from_str(cls, xml_str: Union[str, bytes], root_dir: str):
             etree = etree_from_str(xml_str)
             return cls(
                 root_dir=root_dir,


### PR DESCRIPTION
### GIVEN
* This change deployed to CORGI
### WHEN
* [osbooks-mikroekonomia](https://github.com/openstax/osbooks-mikroekonomia) is built in CORGI
* [osbooks-psychologia](https://github.com/openstax/osbooks-psychologia) is built in CORGI
### THEN
* The job completes successfully

---

# Summary

Quick fix for the two books that failed in the Friday webhost pipeline. They failed because their books.xml file declaration includes an encoding. I also added a test for a variety of encoding scenarios.