### PR TITLE
EPUB font download activation

### DIFF
--- a/bakery-js/src/index.ts
+++ b/bakery-js/src/index.ts
@@ -195,10 +195,7 @@ epubCommand
       )
       writeFileSync(
         `${destinationDir}/${opfFile.parsed.slug}/the-style-epub.css`,
-        cssContents.replace(
-          /@import ([^\n]+)\n/g,
-          '/* commented_for_epub @import $1 */\n'
-        )
+        cssContents
       )
 
       writeFileSync(

--- a/dockerfiles/steps/step-bake.bash
+++ b/dockerfiles/steps/step-bake.bash
@@ -1,1 +1,2 @@
 source $DOCKERFILES_ROOT/steps/bake-util.bash default
+            cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$IO_BAKED"

--- a/dockerfiles/steps/step-pdf.bash
+++ b/dockerfiles/steps/step-pdf.bash
@@ -3,6 +3,7 @@ parse_book_dir
 
 # Style needed because mathjax will size converted math according to surrounding text
 cp "$IO_BAKED/the-style-pdf.css" "$IO_LINKED"
+cp -R "$IO_BAKED/downloaded-fonts" "$IO_LINKED"
 shopt -s globstar nullglob
 for collection in "$IO_LINKED/"*.linked.xhtml; do
     slug_name=$(basename "$collection" | awk -F'[.]' '{ print $1; }')

--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -24,6 +24,7 @@ fi
 style_resource_root="$IO_INITIAL_RESOURCES/styles"
 generic_style="webview-generic.css"
 [[ ! -e "$style_resource_root" ]] && mkdir -p "$style_resource_root"
+cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$style_resource_root"
 while read -r slug_name; do
     style_name=$(read_style "$slug_name")
     web_style="$style_name-web.css"


### PR DESCRIPTION
Activate EPUB font download.

**IMPORTANT**:
This branch is a moment in time (2023-12-15). You have to update/merge Enki AND ce-styles current versions.

For Enki, it's simple
```
git fetch
git checkout epub-font-download-activate
git merge main
```

For ce-styles a little bit more complicated:
* Check which ce-styles is currently in usage in Enki main (probably the last tagged version)
* Merge that version into ce-styles

```
cd ce-styles
git checkout epub-font-download-activate
git fetch
git merge v1.xxx.0
```
