### PR TITLE
2148 versioned interactives

### DIFF
--- a/bakery-src/scripts/fetch_map_resources.py
+++ b/bakery-src/scripts/fetch_map_resources.py
@@ -108,7 +108,6 @@ def main():
 
     filename_to_data = {}
     versioned_root = resources_dir / content_version
-    versioned_root.mkdir(exist_ok=True)
     versioned_subdirs = set()
 
     for child in original_resources_dir.glob('*'):
@@ -146,10 +145,6 @@ def main():
 
             child_directory = new_resource_child_path.parts[0]
             if child_directory not in versioned_subdirs:
-                shutil.move(
-                    resources_dir / child_directory,
-                    versioned_root / child_directory
-                )
                 versioned_subdirs.add(child_directory)
 
             new_resource_src = f"../{dom_resources_dir_name}/{content_version}/{new_resource_child_path}"
@@ -160,6 +155,14 @@ def main():
 
         with cnxml_file.open(mode="wb") as f:
             doc.write(f, encoding="utf-8", xml_declaration=False)
+
+    if len(versioned_subdirs) > 0:
+        versioned_root.mkdir(parents=True)
+        for child_directory in versioned_subdirs:
+            shutil.move(
+                resources_dir / child_directory,
+                versioned_root / child_directory
+            )
 
     all_data_to_json(resources_dir, filename_to_data)
 

--- a/bakery-src/scripts/fetch_map_resources.py
+++ b/bakery-src/scripts/fetch_map_resources.py
@@ -100,12 +100,16 @@ def main():
     in_dir = Path(sys.argv[1]).resolve(strict=True)
     original_resources_dir = Path(sys.argv[2]).resolve(strict=True)
     resources_parent_dir = Path(sys.argv[3]).resolve(strict=True)
+    content_version = sys.argv[4]
     resources_dir = resources_parent_dir / resources_dir_name
     resources_dir.mkdir(exist_ok=True)
 
     cnxml_files = in_dir.glob("**/*.cnxml")
 
     filename_to_data = {}
+    versioned_root = resources_dir / content_version
+    versioned_root.mkdir(exist_ok=True)
+    versioned_subdirs = set()
 
     for child in original_resources_dir.glob('*'):
         if child.is_dir():
@@ -140,7 +144,15 @@ def main():
             new_resource_child_path = resource_original_filepath.relative_to(
                 original_resources_dir)
 
-            new_resource_src = f"../{dom_resources_dir_name}/{new_resource_child_path}"
+            child_directory = new_resource_child_path.parts[0]
+            if child_directory not in versioned_subdirs:
+                shutil.move(
+                    resources_dir / child_directory,
+                    versioned_root / child_directory
+                )
+                versioned_subdirs.add(child_directory)
+
+            new_resource_src = f"../{dom_resources_dir_name}/{content_version}/{new_resource_child_path}"
 
             print(
                 f"rewriting iframe source from {resource_original_src} to {new_resource_src}")

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -2469,6 +2469,7 @@ def test_fetch_map_resources_no_env_variable(tmp_path, mocker):
     initial_resources_dir = resources_parent_dir / "x-initial-resources"
     dom_resources_dir = "resources"
     unused_resources_dir = tmp_path / "unused-resources"
+    commit_sha = "0000000"
 
     book_dir.mkdir(parents=True)
     original_resources_dir.mkdir(parents=True)
@@ -2543,7 +2544,7 @@ def test_fetch_map_resources_no_env_variable(tmp_path, mocker):
     mocker.patch(
         "sys.argv",
         ["", book_dir, original_resources_dir,
-            resources_parent_dir, unused_resources_dir]
+            resources_parent_dir, unused_resources_dir, commit_sha]
     )
     fetch_map_resources.main()
 
@@ -2583,7 +2584,7 @@ def test_fetch_map_resources_no_env_variable(tmp_path, mocker):
         f'<image src="../../media/image_missing.jpg"/>'
         f'<image src="../{dom_resources_dir}/{image_src1_sha1_expected}"/>'
         f'<image src="../{dom_resources_dir}/{image_src2_sha1_expected}"/>'
-        f'<iframe src="../{dom_resources_dir}/interactive/index.xhtml"/>'
+        f'<iframe src="../{dom_resources_dir}/{commit_sha}/interactive/index.xhtml"/>'
         f'</content>'
         f'</document>'
     )
@@ -2607,6 +2608,7 @@ def test_fetch_map_resources_with_env_variable(tmp_path, mocker):
         initial_resources_dir = resources_parent_dir / "initial-resources"
         dom_resources_dir = "myresources"
         unused_resources_dir = tmp_path / "unused-resources"
+        commit_sha = "0000000"
 
         book_dir.mkdir(parents=True)
         original_resources_dir.mkdir(parents=True)
@@ -2681,7 +2683,7 @@ def test_fetch_map_resources_with_env_variable(tmp_path, mocker):
         mocker.patch(
             "sys.argv",
             ["", book_dir, original_resources_dir,
-                resources_parent_dir, unused_resources_dir]
+                resources_parent_dir, unused_resources_dir, commit_sha]
         )
         fetch_map_resources.main()
 
@@ -2721,7 +2723,7 @@ def test_fetch_map_resources_with_env_variable(tmp_path, mocker):
             f'<image src="../../media/image_missing.jpg"/>'
             f'<image src="../{dom_resources_dir}/{image_src1_sha1_expected}"/>'
             f'<image src="../{dom_resources_dir}/{image_src2_sha1_expected}"/>'
-            f'<iframe src="../{dom_resources_dir}/interactive/index.xhtml"/>'
+            f'<iframe src="../{dom_resources_dir}/{commit_sha}/interactive/index.xhtml"/>'
             f'</content>'
             f'</document>'
         )

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -2544,7 +2544,7 @@ def test_fetch_map_resources_no_env_variable(tmp_path, mocker):
     mocker.patch(
         "sys.argv",
         ["", book_dir, original_resources_dir,
-            resources_parent_dir, unused_resources_dir, commit_sha]
+            resources_parent_dir, commit_sha]
     )
     fetch_map_resources.main()
 
@@ -2573,6 +2573,7 @@ def test_fetch_map_resources_no_env_variable(tmp_path, mocker):
         image_src2_meta,
         image_src1_sha1_expected,
         image_src1_meta,
+        commit_sha,
         "interactive",
         "index.xhtml"
     ])
@@ -2683,7 +2684,7 @@ def test_fetch_map_resources_with_env_variable(tmp_path, mocker):
         mocker.patch(
             "sys.argv",
             ["", book_dir, original_resources_dir,
-                resources_parent_dir, unused_resources_dir, commit_sha]
+                resources_parent_dir, commit_sha]
         )
         fetch_map_resources.main()
 
@@ -2712,6 +2713,7 @@ def test_fetch_map_resources_with_env_variable(tmp_path, mocker):
             image_src2_meta,
             image_src1_sha1_expected,
             image_src1_meta,
+            commit_sha,
             "interactive",
             "index.xhtml"
         ])

--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -14,7 +14,7 @@ export HACK_CNX_LOOSENESS=1
 # CNX user books do not always contain media directory
 # Missing media files will still be caught by git-validate-references
 if [[ -d "${media_root:?}" ]]; then
-    fetch-map-resources "${pages_root:?}" "${media_root:?}" "$(dirname $IO_INITIAL_RESOURCES)" "$commit_sha"
+    fetch-map-resources "${pages_root:?}" "${media_root:?}" "$(dirname $IO_INITIAL_RESOURCES)" "${commit_sha:?}"
     rm -rf "$media_root"
 fi
 

--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -1,10 +1,9 @@
 # Formerly git-fetch-metadata
 parse_book_dir
 
-[[ "$ARG_GIT_REF" == latest ]] && ARG_GIT_REF=main
-
 cp -R "$IO_FETCHED/." "$IO_FETCH_META"
 neb pre-assemble "$IO_FETCH_META"
+commit_sha="$(set +x && git -C "$IO_FETCH_META" log --format="%h" -1)"
 rm -rf "$IO_FETCH_META/.git"
 
 repo_info="$(set +x && neb parse-repo "$IO_FETCH_META")"
@@ -15,7 +14,7 @@ export HACK_CNX_LOOSENESS=1
 # CNX user books do not always contain media directory
 # Missing media files will still be caught by git-validate-references
 if [[ -d "${media_root:?}" ]]; then
-    fetch-map-resources "${pages_root:?}" "${media_root:?}" "$(dirname $IO_INITIAL_RESOURCES)"
+    fetch-map-resources "${pages_root:?}" "${media_root:?}" "$(dirname $IO_INITIAL_RESOURCES)" "$commit_sha"
     rm -rf "$media_root"
 fi
 

--- a/test/test-step-03.bash
+++ b/test/test-step-03.bash
@@ -30,7 +30,7 @@ while IFS=$'\n' read -r expected_contents; do
     fi
 done <<EOF
 s3 cp --recursive /tmp/build/0000000/artifacts-single s3://openstax-sandbox-cops-artifacts/apps/archive-localdev/test/contents
-s3 cp --recursive /tmp/build/0000000/resources/interactives-thisnamedoesnotmatter/ s3://openstax-sandbox-cops-artifacts/apps/archive-localdev/test/resources/interactives-thisnamedoesnotmatter
+s3 cp --recursive /tmp/build/0000000/resources/9044eef/ s3://openstax-sandbox-cops-artifacts/apps/archive-localdev/test/resources/9044eef
 s3 cp --recursive /tmp/build/0000000/resources/styles/ s3://openstax-sandbox-cops-artifacts/apps/archive-localdev/test/resources/styles
 s3 cp /tmp/build/0000000/jsonified-single/book-slug1.toc.json s3://openstax-sandbox-cops-artifacts/apps/archive-localdev/test/contents/00000000-0000-0000-0000-000000000000@9044eef.json
 s3 cp /tmp/build/0000000/jsonified-single/book-slug1.toc.xhtml s3://openstax-sandbox-cops-artifacts/apps/archive-localdev/test/contents/00000000-0000-0000-0000-000000000000@9044eef.xhtml


### PR DESCRIPTION
fixes openstax/ce#2148

You may be wondering: why not just move all subdirectories of resources path into a versioned directory? I was a little concerned that, that could break some resource paths. Since we explicitly rewrite iframe resource paths, I thought it would be safer to limit the scope of this change to those. Especially since this is only meant to fix a caching issue. 

Example output with real paths removed (from building a book on hotdog):
`rewriting iframe source from ../../media/interactive/... to ../resources/e5ff71c/interactive/...`