### PR TITLE
2186 use one css file per book when building epub and pdf

### DIFF
--- a/bakery-js/src/index.ts
+++ b/bakery-js/src/index.ts
@@ -190,9 +190,10 @@ epubCommand
 
       // Copy the CSS file to the destination
       const cssContents = readFileSync(
-        `${sourceDir}/${DIRNAMES.IO_BAKED}/the-style-pdf.css`,
+        `${sourceDir}/${DIRNAMES.IO_BAKED}/${opfFile.parsed.slug}-pdf.css`,
         'utf-8'
       )
+      // NOTE: Each css file has the same name in a different book directory
       writeFileSync(
         `${destinationDir}/${opfFile.parsed.slug}/the-style-epub.css`,
         cssContents.replace(

--- a/dockerfiles/steps/bake-util.bash
+++ b/dockerfiles/steps/bake-util.bash
@@ -7,10 +7,11 @@ for collection in "$IO_ASSEMBLED/"*.assembled.xhtml; do
     # use xmlstarlet to pull out the style file unless this ran in CORGI and the CORGI job has an override
     style_name=$(read_style $slug_name)
     style_file="$BOOK_STYLES_ROOT/$style_name-pdf.css"
+    dst_style_name="$slug_name-pdf.css"
 
     if [[ -f "$style_file" ]]
         then
-            cp "$style_file" "$IO_BAKED/the-style-pdf.css"
+            cp "$style_file" "$IO_BAKED/$dst_style_name"
         else
             die "Warning: Style Not Found in '$style_file'" # LCOV_EXCL_LINE
     fi
@@ -20,7 +21,7 @@ for collection in "$IO_ASSEMBLED/"*.assembled.xhtml; do
         then
             export VERBOSE=$TRACE_ON
             $COOKBOOK_ROOT/bake -b "$style_name" -i "$IO_ASSEMBLED/$slug_name.assembled.xhtml" -o "$IO_BAKED/$slug_name.baked.xhtml" -r "$IO_RESOURCES" -p $1
-            sed -i "s%<\\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"the-style-pdf.css\" />&%" "$IO_BAKED/$slug_name.baked.xhtml"
+            sed -i "s%<\\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"$dst_style_name\" />&%" "$IO_BAKED/$slug_name.baked.xhtml"
     fi
 done
 shopt -u globstar nullglob

--- a/test/test-step-12.bash
+++ b/test/test-step-12.bash
@@ -4,7 +4,8 @@ set -e
 [[ $0 != "-bash" ]] && cd "$(dirname "$0")"
 
 install_poetry() {
-    pip install poetry
+    # needs to match version in openstax/python3-poetry
+    pip install 'poetry==1.4.0'
 }
 
 if [[ $CI ]]; then


### PR DESCRIPTION
fixes openstax/ce#2186

Create and use one css file per book slug.

## More details on why the change:
There was a style/recipe name sent to cookbook and a style file copied from ce-styles into later build stages. There was a loop that read the style for each book slug. The loop was continuously overwriting the style file `the-style-pdf.css` which was being used in subsequent steps.

That means that while the correct style/recipe was being used to cookbook, the wrong css file was sometimes being copied to later steps (for bundles where there was more than one style).

This change makes it so bake-util.bash will create one css file per book slug.

- pdf works because prince/mathjax determine which css file to load based on the style in the head (which is inserted by the `sed` command)
- epub works because it reads the css file for the book and saves a modified copy in a subdirectory for each book slug 
