### PR TITLE
Initialize submodules during step-fetch

### DIFF
--- a/dockerfiles/steps/step-fetch.bash
+++ b/dockerfiles/steps/step-fetch.bash
@@ -83,6 +83,8 @@ else
     else
         GIT_TERMINAL_PROMPT=0 git clone --depth 1 "$remote_url" --branch "$ARG_GIT_REF" "$IO_FETCHED"
     fi
+    # Initialize submodules
+    GIT_TERMINAL_PROMPT=0 git -C "$IO_FETCHED" submodule update --init --depth 1
 fi
 
 # Clean up the temporary credentials file if it exists


### PR DESCRIPTION
fixes openstax/ce#2168

More information about what this command does can be found in git/builtin/submodule--helper.c

Short version of what it does:
1. Clone submodule with depth 1
2. Runs `git fetch` if tip is unreachable
3. Runs `git fetch <default-remote> <commit-sha>` if tip is still unreachable
4. Fails if tip is still unreachable
5. Runs `git checkout <commit-sha>` in the submodule