### PR TITLE
2213 ci no codecov

### DIFF
--- a/.github/problem-matcher.json
+++ b/.github/problem-matcher.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "enki",
+      "pattern": [
+        {
+          "regexp": "^([^:]+):\\sline\\s(\\d+),\\scol\\s(\\d+),\\s(Error|Warning|Info)\\s-\\s(.+)\\s\\((.+)\\)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5,
+          "code": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,5 +69,3 @@ jobs:
         run: CI_TEST=true ./test/test-step-08.bash
       - name: Lint scripts
         run: CI_TEST=true ./test/test-step-09.bash
-      - name: Upload Code Coverage
-        uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       #     key: ${{ github.workflow }}-${{ env.WEEK }}-{hash}
       #     restore-keys: |
       #       ${{ github.workflow }}-${{ env.WEEK }}-
+      - name: Install Problem Matchers
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "::add-matcher::.github/problem-matcher.json"
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/dockerfiles/docker-entrypoint-with-kcov.sh
+++ b/dockerfiles/docker-entrypoint-with-kcov.sh
@@ -30,38 +30,28 @@ elif [[ $1 == '__CI_KCOV_MERGE_ALL__' ]]; then
     read -r repo _rest <<< "$dirs_to_merge"
     merged_coverage="$repo/kcov-merged/coverage.json"
     merged_lines="$repo/kcov-merged/codecov.json"
+    # Generate warnings instead of errors to support coverage < 100% (see issue)
     jq -sr '
         .[0] as $input |
         (.[1] | .coverage | to_entries) as $lines |
-        [["File", "%Cov", "Missing"]] +
-        [["----", "----", "-------"]] +
-        [
-            $input | .files | .[] |
-                .file as $file |
-                .percent_covered as $percent_covered |
-                [
-                    $lines | .[] |
-                        .key as $relpath |
-                        select($file | endswith($relpath)) |
-                        .value | to_entries | .[] |
-                            select(.value == 0) |
-                            .key
-                ] | join(",") as $missing_lines |
-                [$file, $percent_covered, $missing_lines]
-        ] +
-        [[], ["Total", ($input | .percent_covered)]] | .[] |
-            (.[0] | .[0:52]) as $col1 |
-            .[1] as $col2 | 
-            .[2] as $col3 |
-            $col1 +
-            (" " * (55 - ($col1 | length))) +
-            $col2 +
-            (" " * (10 - ($col2 | length))) +
-            $col3
+        $input | .files | .[] |
+            .file as $file |
+            .percent_covered as $percent_covered |
+            $lines | .[] |
+                .key as $relpath |
+                select($file | endswith($relpath)) |
+                .value | to_entries | .[] |
+                    select(.value == 0) |
+                    .key as $line |
+                    "\($file | ltrimstr("/")): line \($line), col 1, Warning - line not covered by tests. (coverage-error)"
     ' "$merged_coverage" "$merged_lines"
+    # Here we can decide what our minimum coverage should be
     jq -r '
-        select((.percent_covered | tonumber) < 100) |
-        error("Coverage must be at least 100%")
+        . as $input |
+        100 as $min_coverage |
+        ($input | .percent_covered | tonumber) as $percent_covered |
+        select($percent_covered < $min_coverage) |
+        error("Minimum coverage not met: \($percent_covered)/\($min_coverage)")
     ' "$merged_coverage"
 elif [[ $KCOV_DIR != '' ]]; then
     [[ -d /tmp/build/0000000/$KCOV_DIR ]] || mkdir /tmp/build/0000000/$KCOV_DIR

--- a/test/test-step-08.bash
+++ b/test/test-step-08.bash
@@ -26,10 +26,5 @@ cp -R $DATA_ROOT/kcov-destination/* $COVERAGE_DIR
 echo ""
 echo "DONE: Open $COVERAGE_DIR/index.html in a browser to see the code coverage."
 
-# Upload to codecov only if running inside CI
-if [[ $CI || $CODECOV_TOKEN ]]; then
-    bash <(curl -s https://codecov.io/bash) -Z -s $PWD/../coverage -s $PWD/../bakery-js/coverage
-fi
-
 echo "Checking if bakery-js files are formatted properly. If not, run 'npm run lint:fix'"
 npm --prefix ../bakery-js run lint


### PR DESCRIPTION
fixes openstax/ce#2213

Use jq to generate coverage warnings that are subsequently recognized by a Github problem matcher and annotated in the PR source code/files changed view.

Example: 
<img width="986" alt="Screenshot 2024-04-30 at 2 35 56 PM" src="https://github.com/openstax/enki/assets/33585550/7ab495cb-264b-41f4-b404-a4aba8586cd8">
