### PR TITLE
Disassemble - only use titles to compute id if the element is a chapter or unit

### DIFF
--- a/bakery-src/scripts/html_parser.py
+++ b/bakery-src/scripts/html_parser.py
@@ -294,6 +294,9 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                                                       else None)
             if not id_:
                 fallback_key = None
+                # In case of chapter or unit, the title originates from
+                # the collxml (at the time of writing this). This condition
+                # ensure that titles from cnxml are never used to generate ids.
                 if data_type in ('chapter', 'unit'):
                     fallback_key = metadata.get('title')
                 id_ = _compute_id(parent, child, fallback_key)

--- a/bakery-src/scripts/html_parser.py
+++ b/bakery-src/scripts/html_parser.py
@@ -294,7 +294,7 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                                                       else None)
             if not id_:
                 fallback_key = None
-                if child.get('data-type') in ('chapter',):
+                if data_type in ('chapter', 'unit'):
                     fallback_key = metadata.get('title')
                 id_ = _compute_id(parent, child, fallback_key)
                 assert metadata.get('version')

--- a/bakery-src/scripts/html_parser.py
+++ b/bakery-src/scripts/html_parser.py
@@ -249,6 +249,10 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
 
         assert p_uuid is not None, 'Should always find a parent UUID'
         uuid_key = elem.get('data-uuid-key', elem.get('class', key))
+        assert uuid_key is not None, (
+            f'Could not compute id for {elem.get("data-type")} '
+            f'on line {elem.sourceline}'
+        )
         return str(uuid.uuid5(p_uuid, uuid_key))
 
     def _compute_shortid(ident_hash):
@@ -289,7 +293,10 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                                                       if not uuid_key
                                                       else None)
             if not id_:
-                id_ = _compute_id(parent, child, metadata.get('title'))
+                fallback_key = None
+                if child.get('data-type') in ('chapter',):
+                    fallback_key = metadata.get('title')
+                id_ = _compute_id(parent, child, fallback_key)
                 assert metadata.get('version')
                 metadata['cnx-archive-uri'] = \
                     '@'.join((id_, metadata['version']))


### PR DESCRIPTION
fixes openstax/ce#2234
part of openstax/ce#1528 ("Verify cnx-epub does not rely on metadata title elements for the modules during the disassemble step")

openstax/ce#1528 would see md:title replaced by c:title for modules. Disassemble used titles as a key for generating ids. This PR seeks to clarify and ensure that only titles from collxml md:title tags are used to generate ids. 