### PR TITLE
check_feed: Filter abl_json down to unique entries based on repo and commit sha

### DIFF
--- a/build-concourse/build-corgi.ts
+++ b/build-concourse/build-corgi.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as yaml from 'js-yaml'
 import { buildLookUpBook, GIT_PDF_STEPS, GIT_WEB_STEPS, GIT_GDOC_STEPS, GIT_EPUB_STEPS } from './step-definitions'
-import { KeyValue, JobType, toConcourseTask, loadEnv, wrapGenericCorgiJob, reportToCorgi, Status, RESOURCES, IO, readScript, PDF_OR_WEB, randId, RANDOM_DEV_CODEVERSION_PREFIX, taskMaker, toDockerSourceSection, stepsToTasks } from './util'
+import { KeyValue, JobType, toConcourseTask, loadEnv, wrapGenericCorgiJob, reportToCorgi, Status, RESOURCES, IO, readScript, randId, RANDOM_DEV_CODEVERSION_PREFIX, taskMaker, toDockerSourceSection, stepsToTasks } from './util'
 
 const commonLogFile = `${IO.COMMON_LOG}/log`
 const genericErrorMessage = 'Error occurred in Concourse. See logs for details.'
@@ -52,7 +52,7 @@ function makePipeline(env: KeyValue) {
     const buildPdfJob = (resource: RESOURCES, tasks: any[]) => {
         const report = reportToCorgi(resource)
         const lookupBookDef = buildLookUpBook(resource)
-        const lookupBookTask = taskMaker(env, PDF_OR_WEB.PDF, lookupBookDef)
+        const lookupBookTask = taskMaker(env, lookupBookDef)
         return wrapGenericCorgiJob(env, `build-pdf`, resource, {
             do: [
                 report(Status.ASSIGNED, {
@@ -76,7 +76,7 @@ function makePipeline(env: KeyValue) {
     const buildWebJob = (resource: RESOURCES, tasks: any[]) => {
         const report = reportToCorgi(resource)
         const lookupBookDef = buildLookUpBook(resource)
-        const lookupBookTask = taskMaker(env, PDF_OR_WEB.PDF, lookupBookDef)
+        const lookupBookTask = taskMaker(env, lookupBookDef)
         return wrapGenericCorgiJob(env, `web-preview`, resource, {
             do: [
                 report(Status.ASSIGNED, {
@@ -101,8 +101,7 @@ function makePipeline(env: KeyValue) {
     const buildGitDocxJob = (resource: RESOURCES, tasks: any[]) => {
         const report = reportToCorgi(resource)
         const lookupBookDef = buildLookUpBook(resource)
-        // PDF_OR_WEB argument does not seem to actually do anything
-        const lookupBookTask = taskMaker(env, PDF_OR_WEB.PDF, lookupBookDef)
+        const lookupBookTask = taskMaker(env, lookupBookDef)
         return wrapGenericCorgiJob(env, `build-docx`, resource, {
             do: [
                 report(Status.ASSIGNED, {
@@ -126,8 +125,7 @@ function makePipeline(env: KeyValue) {
     const buildGitEpubJob = (resource: RESOURCES, tasks: any[]) => {
         const report = reportToCorgi(resource)
         const lookupBookDef = buildLookUpBook(resource)
-        // PDF_OR_WEB argument does not seem to actually do anything
-        const lookupBookTask = taskMaker(env, PDF_OR_WEB.PDF, lookupBookDef)
+        const lookupBookTask = taskMaker(env, lookupBookDef)
         return wrapGenericCorgiJob(env, 'build-epub', resource, {
             do: [
                 report(Status.ASSIGNED, {
@@ -146,10 +144,10 @@ function makePipeline(env: KeyValue) {
         })
     }
 
-    const gitPdfJob = buildPdfJob(RESOURCES.CORGI_GIT_PDF, stepsToTasks(env, PDF_OR_WEB.PDF, GIT_PDF_STEPS))
-    const gitWeb = buildWebJob(RESOURCES.CORGI_GIT_WEB, stepsToTasks(env, PDF_OR_WEB.WEB, GIT_WEB_STEPS))
-    const gitDocx = buildGitDocxJob(RESOURCES.CORGI_GIT_DOCX, stepsToTasks(env, PDF_OR_WEB.WEB, GIT_GDOC_STEPS))
-    const gitEpub = buildGitEpubJob(RESOURCES.CORGI_GIT_EPUB, stepsToTasks(env, PDF_OR_WEB.WEB, GIT_EPUB_STEPS))
+    const gitPdfJob = buildPdfJob(RESOURCES.CORGI_GIT_PDF, stepsToTasks(env, GIT_PDF_STEPS))
+    const gitWeb = buildWebJob(RESOURCES.CORGI_GIT_WEB, stepsToTasks(env, GIT_WEB_STEPS))
+    const gitDocx = buildGitDocxJob(RESOURCES.CORGI_GIT_DOCX, stepsToTasks(env, GIT_GDOC_STEPS))
+    const gitEpub = buildGitEpubJob(RESOURCES.CORGI_GIT_EPUB, stepsToTasks(env, GIT_EPUB_STEPS))
 
     const resourceTypes = [
         {

--- a/build-concourse/build-webhosting.ts
+++ b/build-concourse/build-webhosting.ts
@@ -7,7 +7,6 @@ import {
     RESOURCES,
     toConcourseTask,
     expect,
-    PDF_OR_WEB,
     stepsToTasks,
 } from "./util";
 import { GIT_WEB_STEPS_WITH_DEQUEUE_AND_UPLOAD } from "./step-definitions";
@@ -72,7 +71,6 @@ function makePipeline(envValues: KeyValue) {
             },
             ...stepsToTasks(
                 envValues,
-                PDF_OR_WEB.WEB,
                 GIT_WEB_STEPS_WITH_DEQUEUE_AND_UPLOAD
             ),
         ],

--- a/build-concourse/env/webhosting-sandbox.json
+++ b/build-concourse/env/webhosting-sandbox.json
@@ -3,7 +3,7 @@
     "MAX_INFLIGHT_JOBS": 5,
     "AWS_SECRET_ACCESS_KEY": "((aws-sandbox-secret-access-key))",
     "AWS_ACCESS_KEY_ID": "((aws-sandbox-secret-key-id))",
-    "CORGI_API_URL": "https://corgi.ce.sandbox.openstax.org",
+    "CORGI_API_URL": "https://corgi.ce.openstax.org",
     "CORGI_ARTIFACTS_S3_BUCKET": "openstax-sandbox-web-hosting-content-gatekeeper",
     "WEB_S3_BUCKET": "openstax-sandbox-web-hosting-content-gatekeeper",
     "WEB_QUEUE_STATE_S3_BUCKET": "openstax-sandbox-web-hosting-content-queue-state",

--- a/build-concourse/util.ts
+++ b/build-concourse/util.ts
@@ -259,13 +259,7 @@ export const wrapGenericCorgiJob = (env: KeyValue, jobName: string, resource: RE
     }
 }
 
-
-export enum PDF_OR_WEB {
-    PDF = 'pdf',
-    WEB = 'web'
-}
-
-  export const taskMaker = (env: KeyValue, pdfOrWeb: PDF_OR_WEB, step: Step) => toConcourseTask(env, step.name, step.inputs, [...step.outputs, IO.COMMON_LOG], { TASK_NAME: step.name, CODE_VERSION: true, ...step.env }, readScript('script/run_task.bash'))
+  export const taskMaker = (env: KeyValue, step: Step) => toConcourseTask(env, step.name, step.inputs, [...step.outputs, IO.COMMON_LOG], { TASK_NAME: step.name, CODE_VERSION: true, ...step.env }, readScript('script/run_task.bash'))
   
 
 type Settings = { 
@@ -313,8 +307,8 @@ export function loadEnv(pathToJson: string) {
     return env
 }
 
-export function stepsToTasks(env: KeyValue, pdfOrWeb: PDF_OR_WEB, steps: Step[]): ConcourseTask[] {
-    return steps.map(step => taskMaker(env, pdfOrWeb, step))
+export function stepsToTasks(env: KeyValue, steps: Step[]): ConcourseTask[] {
+    return steps.map(step => taskMaker(env, step))
 }
 
 export type KeyValue = {


### PR DESCRIPTION
The webhosting pipeline builds all books in a repository; therefore, we only need to queue each version of a repository once. 