### PR TITLE
Ignore errors related to pre tags in epub validation

### DIFF
--- a/dockerfiles/steps/step-epub.bash
+++ b/dockerfiles/steps/step-epub.bash
@@ -49,6 +49,7 @@ for epub_file in "$IO_ARTIFACTS/"*.epub; do
         #     | grep -v 'ERROR(RSC-012)' \
         #     | grep -v 'ERROR(MED-002)' \
         # )
+        # TODO: Instead of ignoring errors related to pre tags, maybe use code elements instead where inline elements are expected (https://www.w3schools.com/htmL/html_blocks.asp)
         errors=$(cat $IO_ARTIFACTS/$epub_filename.validation.log | grep 'ERROR' \
             | grep -v 'Error while parsing file: attribute "display" not allowed here;' \
             | grep -v 'Error while parsing file: value of attribute "target" is invalid;' \
@@ -62,6 +63,8 @@ for epub_file in "$IO_ARTIFACTS/"*.epub; do
             \
             | grep -v 'Error while parsing file: attribute "rules" not allowed here;' \
             | grep -v 'Error while parsing file: attribute "align" not allowed here;' \
+            \
+            | grep -v 'Error while parsing file: element "pre" not allowed here;' \
             ;
         )
 


### PR DESCRIPTION
# Quick background: 

For future reference, here are some examples of where this is a problem:
```html
<h3 data-type="title">...<pre data-type="code" class="python inline-code" data-lang="python">...</pre></h3>
<span class="os-title" data-type="title">...<pre data-type="code" class="python inline-code" data-lang="python">...</pre></span>
<span class="os-caption" data-type="title">...<pre data-type="code" class="python inline-code" data-lang="python">...</pre></span>
```

The python book (and likely data-science as well) have code in titles and captions. This code is converted into `pre` during `step-assemble`. Since the title element is a span (inline), it is not supposed to contain a block-level element -> validation error.

In summary:
* `span` tags cannot contain block-level `pre` tags
* `h3` tags should only contain [Phrasing Content](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content) which does not include `pre` tags

A possible long-term solution to this problem would be to modify cnxml-to-html5.xsl so that it converts code to `code` with `white-space: pre` instead of `pre` if the code is inside of an inline element.

For our current purposes, however, ignoring the problem seems like the best route because we have not found any perceptible defects caused by these errors in the finished epub build.