### PR TITLE
Epub font download activate rebased

### DIFF
--- a/bakery-js/src/index.ts
+++ b/bakery-js/src/index.ts
@@ -196,10 +196,7 @@ epubCommand
       // NOTE: Each css file has the same name in a different book directory
       writeFileSync(
         `${destinationDir}/${opfFile.parsed.slug}/the-style-epub.css`,
-        cssContents.replace(
-          /@import ([^\n]+)\n/g,
-          '/* commented_for_epub @import $1 */\n'
-        )
+        cssContents
       )
 
       writeFileSync(

--- a/bakery-src/scripts/pptify_book.py
+++ b/bakery-src/scripts/pptify_book.py
@@ -474,15 +474,13 @@ def auto_crop_img(img, bg=None):
 # due to some kind of rate limiting. If this becomes a problem, a possible
 # workaround is to download the font css once and update the references in the
 # pdf css so that the font is read from the local copy
-def xhtml_to_img(elem, *, css=[], resource_dir=None):
+def xhtml_to_img(elem, *, css=[]):
     options = {
         "format": "png",
-        "log-level": "error",
+        "log-level": "warn",
         "quality": "100",
+        "enable-local-file-access": "",
     }
-    if resource_dir is not None:
-        options["enable-local-file-access"] = ""
-        options["allow"] = resource_dir
     with BytesIO() as img_file:
         serialized = etree.tostring(elem, encoding="unicode")
         assert serialized, "Cannot convert empty element"
@@ -511,7 +509,7 @@ def element_to_image(
         rel_p = resource.get(attr)
         abs_p = (doc_dir / rel_p).resolve()
         resource.set(attr, str(abs_p))
-    img = xhtml_to_img(elem, resource_dir=resource_dir, css=css)
+    img = xhtml_to_img(elem, css=css)
     img = auto_crop_img(img)
     return img
 

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -4598,24 +4598,24 @@ def test_ppt_image_transforms(mocker):
         css=[],
         options={
             "format": "png",
-            "log-level": "error",
+            "log-level": "warn",
             "quality": "100",
+            "enable-local-file-access": "",
         },
     )
     assert result.size == img.size
 
     imgkit_from_string_stub.reset_mock()
-    result = pptify_book.xhtml_to_img(xhtml, resource_dir="test")
+    result = pptify_book.xhtml_to_img(xhtml)
     imgkit_from_string_stub.assert_called_once_with(
         etree.tostring(xhtml, encoding="unicode"),
         None,
         css=[],
         options={
-            "allow": "test",
-            "enable-local-file-access": "",
             "format": "png",
-            "log-level": "error",
+            "log-level": "warn",
             "quality": "100",
+            "enable-local-file-access": "",
         },
     )
     assert result.size == img.size
@@ -4652,11 +4652,10 @@ def test_ppt_image_transforms(mocker):
         None,
         css=[],
         options={
-            "allow": resource_dir,
-            "enable-local-file-access": "",
             "format": "png",
-            "log-level": "error",
+            "log-level": "warn",
             "quality": "100",
+            "enable-local-file-access": "",
         },
     )
     mocker.stopall()

--- a/dockerfiles/steps/bake-util.bash
+++ b/dockerfiles/steps/bake-util.bash
@@ -1,6 +1,7 @@
 parse_book_dir
 
 shopt -s globstar nullglob
+cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$IO_BAKED"
 for collection in "$IO_ASSEMBLED/"*.assembled.xhtml; do
     slug_name=$(basename "$collection" | awk -F'[.]' '{ print $1; }')
 

--- a/dockerfiles/steps/step-bake.bash
+++ b/dockerfiles/steps/step-bake.bash
@@ -1,1 +1,2 @@
 source $DOCKERFILES_ROOT/steps/bake-util.bash default
+            cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$IO_BAKED"

--- a/dockerfiles/steps/step-bake.bash
+++ b/dockerfiles/steps/step-bake.bash
@@ -1,2 +1,1 @@
 source $DOCKERFILES_ROOT/steps/bake-util.bash default
-            cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$IO_BAKED"

--- a/dockerfiles/steps/step-pdf.bash
+++ b/dockerfiles/steps/step-pdf.bash
@@ -2,7 +2,7 @@
 parse_book_dir
 
 # Style needed because mathjax will size converted math according to surrounding text
-cp "$IO_BAKED/the-style-pdf.css" "$IO_LINKED"
+cp "$IO_BAKED/"*-pdf.css "$IO_LINKED"
 cp -R "$IO_BAKED/downloaded-fonts" "$IO_LINKED"
 shopt -s globstar nullglob
 for collection in "$IO_LINKED/"*.linked.xhtml; do

--- a/dockerfiles/steps/step-pdf.bash
+++ b/dockerfiles/steps/step-pdf.bash
@@ -2,7 +2,8 @@
 parse_book_dir
 
 # Style needed because mathjax will size converted math according to surrounding text
-cp "$IO_BAKED/"*-pdf.css "$IO_LINKED"
+cp "$IO_BAKED/the-style-pdf.css" "$IO_LINKED"
+cp -R "$IO_BAKED/downloaded-fonts" "$IO_LINKED"
 shopt -s globstar nullglob
 for collection in "$IO_LINKED/"*.linked.xhtml; do
     slug_name=$(basename "$collection" | awk -F'[.]' '{ print $1; }')

--- a/dockerfiles/steps/step-pptx.bash
+++ b/dockerfiles/steps/step-pptx.bash
@@ -2,6 +2,7 @@ parse_book_dir
 
 set -Eeuo pipefail
 
+cp -R "$IO_BAKED/downloaded-fonts" "/tmp"
 mathml2png_rpc start
 for book in "$IO_LINKED/"*.xhtml; do
     lang=en

--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -33,6 +33,7 @@ fi
 style_resource_root="$IO_INITIAL_RESOURCES/styles"
 generic_style="webview-generic.css"
 [[ ! -e "$style_resource_root" ]] && mkdir -p "$style_resource_root"
+cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$style_resource_root"
 while read -r slug_name; do
     style_name=$(read_style "$slug_name")
     web_style="$style_name-web.css"

--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -33,7 +33,8 @@ fi
 style_resource_root="$IO_INITIAL_RESOURCES/styles"
 generic_style="webview-generic.css"
 [[ ! -e "$style_resource_root" ]] && mkdir -p "$style_resource_root"
-cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$style_resource_root"
+# Disable upload to S3
+# cp -R "$BOOK_STYLES_ROOT/downloaded-fonts" "$style_resource_root"
 while read -r slug_name; do
     style_name=$(read_style "$slug_name")
     web_style="$style_name-web.css"


### PR DESCRIPTION
part of openstax/ce#2083

- Copy downloaded fonts where required (pdf, epub, and pptx)
- Do not upload fonts to S3 (this may have created a problem last time due to the replicator? Also, there's not reason to do it since the fonts are not used in the webview style.)
- Remove some unnecessary parts of `xhtml_to_img` in `pptify_book` (The `enable-local-file-access` option allows general file access and you do not need to specify specific directories in this case.)
- Set log level to `warn` for imgkit in pptify_book (warn is the minimum level that logs missing files)
- Update tests for `pptify_book` to reflect changes.

**Note**: This should not be merged before the ce-styles [PR](https://github.com/openstax/ce-styles/pull/549) that enables local fonts due to the changes in bakery-js/src/index.ts (see: failing tests).