### PR TITLE
Annotate xml files faster; enable annotation on corgi

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -292,6 +292,12 @@ function parse_book_dir() {
 
     [[ -f $IO_BOOK/repo ]] && ARG_REPO_NAME="$(cat $IO_BOOK/repo)"
     ARG_GIT_REF="$(cat $IO_BOOK/version)"
+    ARG_ENABLE_CORGI_UPLOAD=0
+    ARG_ENABLE_SOURCEMAPS=0
+    if [[ -f $IO_BOOK/job_id ]]; then
+        ARG_ENABLE_CORGI_UPLOAD=1
+        ARG_ENABLE_SOURCEMAPS=1
+    fi
 }
 
 # Concourse-CI runs each step in a separate process so parse_book_dir() needs to
@@ -299,6 +305,8 @@ function parse_book_dir() {
 function unset_book_vars() {
     unset ARG_REPO_NAME
     unset ARG_GIT_REF
+    unset ARG_ENABLE_CORGI_UPLOAD
+    unset ARG_ENABLE_SOURCEMAPS
 }
 
 function do_step() {

--- a/dockerfiles/steps/step-prebake.bash
+++ b/dockerfiles/steps/step-prebake.bash
@@ -9,6 +9,12 @@ media_root="$(set +x && echo "$repo_info" | jq -r '.container.media_root')"
 not_found="$(grep -vFxf <(read_book_slugs --from-repo) <(read_book_slugs) || echo -n)"
 [[ -z "$not_found" ]] || die "Slug(s) not found in repository:\n$not_found\n\nValid options are:\n$(read_book_slugs --from-repo)"
 
+if [[ $ARG_ENABLE_SOURCEMAPS == 1 ]]; then
+    pushd $IO_FETCH_META > /dev/null
+    find . -name '*.cnxml' -or -name '*.collection.xml' | node --unhandled-rejections=strict "${JS_EXTRA_VARS[@]}" "$JS_UTILS_STUFF_ROOT/bin/bakery-helper" add-sourcemap-info --in-place
+    popd > /dev/null
+fi
+
 neb pre-assemble "$IO_FETCH_META"
 commit_sha="$(set +x && git -C "$IO_FETCH_META" log --format="%h" -1)"
 rm -rf "$IO_FETCH_META/.git"
@@ -84,18 +90,6 @@ parse_book_dir
 cp -r "$IO_INITIAL_RESOURCES/." "$IO_RESOURCES"
 
 repo_root=$IO_FETCH_META
-
-# TODO: Pass file name pattern to node command and avoid the loop below
-if [[ $LOCAL_ATTIC_DIR != '' ]]; then
-    echo 'Annotating XML files with source map information (data-sm="...")'
-    pushd $IO_FETCH_META > /dev/null
-    files=$(find . -name '*.cnxml' -or -name '*.collection.xml')
-    for file in $files; do
-        node --unhandled-rejections=strict "${JS_EXTRA_VARS[@]}"  "$JS_UTILS_STUFF_ROOT/bin/bakery-helper" add-sourcemap-info "$file" "$file"
-    done
-    echo "XML files annotated successfully!"
-    popd > /dev/null
-fi
 
 neb assemble "$repo_root" "$IO_ASSEMBLED" "$IO_RESOURCES"
 

--- a/dockerfiles/steps/step-upload-book.bash
+++ b/dockerfiles/steps/step-upload-book.bash
@@ -48,9 +48,9 @@ for collection in "$IO_JSONIFIED/"*.toc.json; do
 done
 
 # Only do this when we are running a CORGI job
-if [[ -f "$IO_BOOK/job_id" ]]; then
+if [[ $ARG_ENABLE_CORGI_UPLOAD == 1 ]]; then
     for varname in CORGI_CLOUDFRONT_URL REX_PROD_PREVIEW_URL; do
-        expect_value "${!varname-}" "step-upload-book: Expected value for \"$varname\""
+        : ${!varname:?"Expected value for \"$varname\""}
     done
     book_slug_urls=()
     while read -r book_slug; do


### PR DESCRIPTION
part of openstax/ce#2073

Pipe a list of files to the node process so that we do not need to start a new instance of node for each file annotated

Enable annotation if IO_BOOK/job_id exists (true for local and corgi)

See changes to the `if` in step-upload-book.bash for additional background on the reasoning behind using IO_BOOK/job_id.