### PR TITLE
Assemble: Make note title a footnote dumpsite

### DIFF
--- a/nebuchadnezzar/nebu/tests/snapshots/test_converters/test_diffs/footnote.xhtml
+++ b/nebuchadnezzar/nebu/tests/snapshots/test_converters/test_diffs/footnote.xhtml
@@ -85,14 +85,14 @@
 
 <div data-type="note"><div data-type="title">
     <a href="#linktome-nt" role="doc-noteref" epub:type="noteref">[footnote]</a>
-  </div>
+  </div><aside role="doc-footnote" epub:type="footnote" id="linktome-nt">should move below the title or below the note</aside>
   <p>
     <a href="#linktome-np" role="doc-noteref" epub:type="noteref">[footnote]</a>
     <sup>
       <a href="#linktome-nps" role="doc-noteref" epub:type="noteref">[footnote]</a>
     </sup>
   </p><aside role="doc-footnote" epub:type="footnote" id="linktome-np">should move below the para</aside><aside role="doc-footnote" epub:type="footnote" id="linktome-nps">should move below the para</aside>
-<aside role="doc-footnote" epub:type="footnote" id="linktome-nt">should move below the title or below the note</aside></div>
+</div>
 
 <div data-type="exercise">
   <div data-type="problem">

--- a/nebuchadnezzar/nebu/xsl/cnxml-to-html5.xsl
+++ b/nebuchadnezzar/nebu/xsl/cnxml-to-html5.xsl
@@ -594,7 +594,27 @@
   </xsl:attribute>
 </xsl:template>
 
-<xsl:template match="c:note">
+<xsl:template match="c:note[c:title]">
+  <div data-type="{local-name()}">
+    <xsl:if test="c:label">
+      <xsl:attribute name="data-has-label">true</xsl:attribute>
+    </xsl:if>
+    <xsl:apply-templates select="@*"/>
+    <xsl:if test="c:label">
+      <xsl:call-template name="apply-template-no-selfclose">
+        <xsl:with-param name="selection" select="c:label"/>
+      </xsl:call-template>
+    </xsl:if>
+    <xsl:apply-templates select="c:title"/>
+    <xsl:apply-templates mode="footnote-dumpsite" select="c:title"/>
+    <xsl:call-template name="apply-template-no-selfclose">
+      <xsl:with-param name="selection" select="node()[not(self::c:title or self::c:label)]"/>
+    </xsl:call-template>
+    <xsl:apply-templates mode="footnote-dumpsite" select="."/>
+  </div>
+</xsl:template>
+
+<xsl:template match="c:note[not(c:title)]">
   <div data-type="{local-name()}">
     <xsl:if test="c:label">
       <xsl:attribute name="data-has-label">true</xsl:attribute>
@@ -951,6 +971,7 @@
     | c:section
     | c:section/c:title
     | c:note
+    | c:note/c:title
     | c:example
     | c:problem
     | c:solution
@@ -972,6 +993,7 @@
     | c:section
     | c:section/c:title
     | c:note
+    | c:note/c:title
     | c:example
     | c:problem
     | c:solution


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-740

1. Footnote asides are added outside of parent elements to the nearest footnote dumpsite
1. Note titles were not a footnote dumpsite
1. Footnotes from note titles were added to the next nearest dumpsite: note body
1. There is a template for para that has higher priority than the note template
1. ~Since these both dumped to note body and para had higher priority, the para footnote was added to the note body before the title footnote. This caused incorrect ordering.~ Correction: Since para is a footnote dumpsite, the aside for the footnote para was added immediately after the para, which is why it came before the aside for the note title para and why the numbering was reversed.

Solution: make note titles a footnote dumpsite and then dump title footnotes while processing the note.