### PR TITLE
CORE-1006 - WebHosting Slack Notifications

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
       #     key: ${{ github.workflow }}-${{ env.WEEK }}-{hash}
       #     restore-keys: |
       #       ${{ github.workflow }}-${{ env.WEEK }}-
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - name: Install Problem Matchers
         if: ${{ github.event_name == 'pull_request' }}
         run: echo "::add-matcher::.github/problem-matcher.json"

--- a/bakery-js/src/index.ts
+++ b/bakery-js/src/index.ts
@@ -270,13 +270,17 @@ program
     const readline = createInterface({ input: process.stdin })
     log('Annotating XML files with source map information (data-sm="...")')
     for await (const sourceFile of progressSpinner(readline)) {
-      const destinationFile = inPlace ? sourceFile : `${sourceFile}.mapped`
-      const $doc = dom(await readXmlWithSourcemap(sourceFile))
-      $doc.forEach('//*[not(@data-sm)]', (el) => {
-        const p = getPos(el.node)
-        el.attr('data-sm', `${sourceFile}:${p.lineNumber}:${p.columnNumber}`)
-      })
-      await writeXmlWithSourcemap(destinationFile, $doc.node)
+      try {
+        const destinationFile = inPlace ? sourceFile : `${sourceFile}.mapped`
+        const $doc = dom(await readXmlWithSourcemap(sourceFile))
+        $doc.forEach('//*[not(@data-sm)]', (el) => {
+          const p = getPos(el.node)
+          el.attr('data-sm', `${sourceFile}:${p.lineNumber}:${p.columnNumber}`)
+        })
+        await writeXmlWithSourcemap(destinationFile, $doc.node)
+      } catch (e) {
+        log(`\n[ERROR] Failed to annotate ${sourceFile}: ${e}\n`)
+      }
     }
     log('XML files annotated successfully!\n')
   })

--- a/bakery-src/scripts/check_feed.py
+++ b/bakery-src/scripts/check_feed.py
@@ -88,7 +88,7 @@ class QueueNotifier(NamedTuple):
                 self.s3_client.delete_object(
                     Bucket=self.queue_state_bucket, Key=self.notification_key
                 )
-            except botocore.exceptions.ClientError as error: # pragma: no cover
+            except botocore.exceptions.ClientError as error:  # pragma: no cover
                 if not is_status_code(error, "404"):
                     raise
 

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -24,6 +24,7 @@ from PIL import Image, ImageDraw
 from pathlib import Path
 from filecmp import cmp
 import unittest
+import sys
 
 try:
     from unittest import mock
@@ -1131,7 +1132,7 @@ def test_bake_book_metadata_git(tmp_path, mocker):
     assert book_metadata["language"] == "en"
 
 
-def test_check_feed(tmp_path, mocker):
+def test_check_feed(mocker):
     """Test check_feed script"""
 
     input_book_feed = [
@@ -1168,14 +1169,15 @@ def test_check_feed(tmp_path, mocker):
 
     api_root = "https://mock.corgi"
 
-    class MockResponse:
+    class MockBookFeedResponse:
+        def __init__(self, book_feed):
+            self.book_feed = book_feed
+
         def json(self):
-            return input_book_feed
+            return self.book_feed
 
         def raise_for_status(self):
             pass
-
-    check_feed.requests.get = lambda url: MockResponse()
 
     # We'll use the botocore stubber to play out a simple scenario to test the
     # script where we'll trigger multiple invocations to "build" all books
@@ -1203,6 +1205,10 @@ def test_check_feed(tmp_path, mocker):
 
     s3_client = boto3.client("s3")
     s3_stubber = botocore.stub.Stubber(s3_client)
+
+    # Let's not risk creating spam by accident
+    assert os.getenv("SLACK_WEBHOOKS", "") == ""
+    assert os.getenv("SLACK_POST_PARAMS", "") == ""
 
     def _stubber_add_head_object_404(expected_key):
         s3_stubber.add_client_error(
@@ -1232,6 +1238,16 @@ def test_check_feed(tmp_path, mocker):
                 "Bucket": queue_state_bucket,
                 "Key": expected_key,
                 "Body": expected_body,
+            },
+        )
+    
+    def _stubber_delete_object(expected_key):
+        s3_stubber.add_response(
+            "delete_object",
+            {},
+            expected_params={
+                "Bucket": queue_state_bucket,
+                "Key": expected_key,
             },
         )
 
@@ -1269,7 +1285,9 @@ def test_check_feed(tmp_path, mocker):
         botocore.stub.ANY,
     )
 
-    # Book: Check for .complete file
+    _stubber_add_head_object_404(f"{code_version}/notification.complete")
+
+    # Book repo 1: Check for .complete file
     _stubber_add_head_object(
         f"{code_version}/.{state_prefix}.{repo1}@{vers1}.complete"
     )
@@ -1277,6 +1295,12 @@ def test_check_feed(tmp_path, mocker):
     # Book repo 2: This one is complete, no action
     _stubber_add_head_object(
         f"{code_version}/.{state_prefix}.{repo2}@{vers2}.complete"
+    )
+
+    _stubber_add_head_object_404(f"{code_version}/notification.complete")
+    _stubber_add_put_object(
+        f"{code_version}/notification.complete",
+        botocore.stub.ANY
     )
 
     s3_stubber.activate()
@@ -1296,10 +1320,39 @@ def test_check_feed(tmp_path, mocker):
         ],
     )
 
-    for _ in range(2):
-        check_feed.main()
+    send_slack_message = check_feed.send_slack_message
+    mock_send_slack_message = unittest.mock.Mock(wraps=send_slack_message)
+    mock_datetime = unittest.mock.Mock()
+    mock_datetime.now.return_value = datetime.fromtimestamp(0)
+
+    check_feed.requests.get = lambda url: MockBookFeedResponse(input_book_feed)
+
+    with (
+        unittest.mock.patch(
+            'bakery_scripts.check_feed.send_slack_message', mock_send_slack_message
+        ),
+        unittest.mock.patch(
+            'bakery_scripts.check_feed.datetime', mock_datetime
+        )
+    ):
+        for _ in range(2):
+            check_feed.main()
+    
+    # Should try to send one slack notification
+    assert [call.args for call in mock_send_slack_message.call_args_list] == [
+        (
+            'WebHosting Pipeline Status Update\n'
+            '\n'
+            'Version: 20210101.00000001\n'
+            'Build Status: Complete ✅\n'
+            'Completion Time: 1970-01-01T00:00:00+00:00\n'
+            'Total Books Built: 2',
+        ),
+    ]
 
     s3_stubber.assert_no_pending_responses()
+
+    _stubber_add_head_object(f"{code_version}/notification.complete")    
 
     mocker.patch(
         "sys.argv",
@@ -1313,10 +1366,228 @@ def test_check_feed(tmp_path, mocker):
             state_prefix,
         ],
     )
-
-    check_feed.main()
+    with unittest.mock.patch(
+        'bakery_scripts.check_feed.send_slack_message', mock_send_slack_message
+    ):
+        check_feed.main()
+    
+    # Should not try to send another slack notification
+    assert mock_send_slack_message.call_count == 1
 
     s3_stubber.assert_no_pending_responses()
+
+    second_book_feed = [
+        {
+            "repository_name": "osbooks-introduction-sociology",
+            "code_version": "20210224.204120",
+            "uuid": "02040312-72c8-441e-a685-20e9333f3e1e",
+            "slug": "introduction-sociology-not-2e",
+            "committed_at": "2022-02-09T17:32:00+00:00",
+            "consumer": "REX",
+            "commit_sha": "1" * 40,
+        },
+    ]
+
+    repo1 = second_book_feed[0]["repository_name"]
+    vers1 = second_book_feed[0]["commit_sha"]
+    book = {"repo": repo1, "version": vers1}
+
+    check_feed.requests.get = lambda url: MockBookFeedResponse(second_book_feed)
+
+    # Book: Check for .complete file
+    _stubber_add_head_object_404(
+        f"{code_version}/.{state_prefix}.{repo1}@{vers1}.complete"
+    )
+
+    # Book: Check for .pending file
+    _stubber_add_head_object_404(
+        f"{code_version}/.{state_prefix}.{repo1}@{vers1}.pending"
+    )
+
+    # Book: Put book data
+    _stubber_add_put_object(queue_filename, json.dumps(book))
+
+    # Book: Put book .pending
+    _stubber_add_put_object(
+        f"{code_version}/.{state_prefix}.{repo1}@{vers1}.pending",
+        botocore.stub.ANY,
+    )
+
+    # We did notify
+    _stubber_add_head_object(f"{code_version}/notification.complete")
+    # We want to notify again
+    _stubber_add_head_object(f"{code_version}/notification.complete")
+    _stubber_delete_object(f"{code_version}/notification.complete")
+
+    # Book repo 1: Check for .complete file
+    _stubber_add_head_object(
+        f"{code_version}/.{state_prefix}.{repo1}@{vers1}.complete"
+    )
+
+    # Now we notify about completion again
+    _stubber_add_head_object_404(f"{code_version}/notification.complete")
+    _stubber_add_put_object(
+        f"{code_version}/notification.complete",
+        botocore.stub.ANY
+    )
+
+    mocker.patch(
+        "sys.argv",
+        [
+            "",
+            api_root,
+            code_version,
+            queue_state_bucket,
+            queue_filename,
+            1,
+            state_prefix,
+        ],
+    )
+
+    with (
+        unittest.mock.patch(
+            'bakery_scripts.check_feed.send_slack_message', mock_send_slack_message
+        ),
+        unittest.mock.patch(
+            'bakery_scripts.check_feed.datetime', mock_datetime
+        )
+    ):
+        for _ in range(2):
+            check_feed.main()
+    
+    assert [call.args for call in mock_send_slack_message.call_args_list] == [
+        (
+            'WebHosting Pipeline Status Update\n'
+            '\n'
+            'Version: 20210101.00000001\n'
+            'Build Status: Complete ✅\n'
+            'Completion Time: 1970-01-01T00:00:00+00:00\n'
+            'Total Books Built: 2',
+        ),
+        (
+            'WebHosting Pipeline Status Update\n'
+            '\n'
+            'Version: 20210101.00000001\n'
+            'Build Status: Running ▶️\n'
+            'Start Time: 1970-01-01T00:00:00+00:00\n'
+            'Books Queued: 1',
+        ),
+        (
+            'WebHosting Pipeline Status Update\n'
+            '\n'
+            'Version: 20210101.00000001\n'
+            'Build Status: Complete ✅\n'
+            'Completion Time: 1970-01-01T00:00:00+00:00\n'
+            'Total Books Built: 1',
+        ),
+    ]
+    
+    s3_stubber.assert_no_pending_responses()
+
+
+@pytest.fixture
+def capsys(capsys):
+    # Override capsys fixture to include stderr
+    class CustomCapture(object):
+        def __init__(self, capsys):
+            self.capsys = capsys
+
+        def write(self, message):
+            self.capsys.write(message)
+
+        def flush(self):
+            pass
+
+    class CustomStderr(object):
+        def __init__(self, capsys):
+            self.capsys = capsys
+
+        def write(self, message):
+            self.capsys.stderr.write(message)
+
+        def flush(self):
+            pass
+
+    sys.stdout = CustomCapture(capsys)
+    sys.stderr = CustomStderr(capsys)
+    yield capsys
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+
+
+@pytest.mark.parametrize("webhook_urls,post_params,status", [
+    (("single_webhook",), [], 200),
+    (("webhook1", "webhook2"), [], 200),
+    (
+        [],
+        [
+            {
+                "token": "1234",
+                "as_user": "slack_user",
+                "link_names": True,
+                "channel": "slack_channel",
+            }
+        ],
+        200
+    ),
+    (("single_webhook",), [], 403),
+    ([], [{}], 400),
+])
+def test_check_feed_slack_messages(capsys, webhook_urls, post_params, status):
+    with (
+        unittest.mock.patch.dict(os.environ, clear=True) as env,
+        unittest.mock.patch('bakery_scripts.check_feed.requests') as mock_requests,
+    ):
+        expected_message = "Test Message"
+        response = unittest.mock.Mock()
+        response.status_code = status
+        if status != 200:
+            def create_error():
+                raise Exception(str(status))
+            response.raise_for_status = create_error
+
+        mock_requests.post.return_value = response
+        if webhook_urls:
+            env.update({"SLACK_WEBHOOKS": ",".join(webhook_urls)})
+        if post_params:
+            env.update({"SLACK_POST_PARAMS": json.dumps(post_params)})
+        
+        check_feed.send_slack_message(expected_message)
+        assert mock_requests.post.call_count == len(webhook_urls) + len(post_params)
+
+        assert [
+            {"args": call.args, "kwargs": call.kwargs}
+            for call in mock_requests.post.call_args_list
+        ] == [
+            {"args": (webhook,), "kwargs": {"json": {"text": expected_message}}}
+            for webhook in webhook_urls
+        ] + [
+            {
+                "args": ("https://slack.com/api/chat.postMessage",),
+                "kwargs": {"data": {**params, "text": expected_message}}
+            }
+            for params in post_params
+        ]
+        if status != 200:
+            captured = capsys.readouterr()
+            assert captured.err.strip() == f"Error sending message: {status}"
+
+
+def test_check_feed_slack_messages_invalid_input(capsys):
+    with (
+        unittest.mock.patch.dict(os.environ, clear=True) as env,
+        unittest.mock.patch('bakery_scripts.check_feed.requests') as mock_requests,
+    ):
+        env.update({"SLACK_POST_PARAMS": "invalid_json"})
+        check_feed.send_slack_message("doesn't matter")
+        captured = capsys.readouterr()
+        assert captured.err.startswith("Invalid JSON in SLACK_POST_PARAMS")
+        assert mock_requests.post.call_count == 0
+        env.update({"SLACK_POST_PARAMS": json.dumps("not a dict")})
+        check_feed.send_slack_message("doesn't matter")
+        captured = capsys.readouterr()
+        assert captured.err.startswith("Invalid post params")
+        assert mock_requests.post.call_count == 0
 
 
 def test_patch_same_book_links(tmp_path, mocker):
@@ -1675,7 +1946,7 @@ async def test_gdocify_book(tmp_path, mocker):
     assert len(unwanted_nodes) == 0
 
     unwanted_nodes = updated_doc.xpath(
-        f'//x:mi[contains(text(), "\u0338")]|//x:mn[contains(text(), "\u0338")]',
+        '//x:mi[contains(text(), "\u0338")]|//x:mn[contains(text(), "\u0338")]',
         namespaces={"x": "http://www.w3.org/1999/xhtml"},
     )
     assert len(unwanted_nodes) == 0

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -1155,11 +1155,11 @@ def test_check_feed(mocker):
             "consumer": "REX",
             "commit_sha": "ffffffffffffffffffffffffffffffffffffffff",
         },
-        # It should not try to queue this version: repo and commit match prev
+        # It should NOT try to queue this version: repo and commit match prev
         {
             "repository_name": "osbooks-introduction-sociology",
             "code_version": "20210224.204120",
-            "uuid": "02040312-72c8-441e-a685-20e9333f3e1e",
+            "uuid": "02040312-72c8-441e-a685-20e9333f3e1d",
             "slug": "introduction-sociology-not-2e",
             "committed_at": "2022-02-09T17:32:00+00:00",
             "consumer": "REX",
@@ -1346,7 +1346,9 @@ def test_check_feed(mocker):
             'Version: 20210101.00000001\n'
             'Build Status: Complete ✅\n'
             'Completion Time: 1970-01-01T00:00:00+00:00\n'
-            'Total Books Built: 2',
+            'Books Built: 2\n'
+            'Total Books: 2\n'
+            'Failed Builds: 0',
         ),
     ]
 
@@ -1415,8 +1417,7 @@ def test_check_feed(mocker):
 
     # We did notify
     _stubber_add_head_object(f"{code_version}/notification.complete")
-    # We want to notify again
-    _stubber_add_head_object(f"{code_version}/notification.complete")
+    # We want to reset
     _stubber_delete_object(f"{code_version}/notification.complete")
 
     # Book repo 1: Check for .complete file
@@ -1455,6 +1456,11 @@ def test_check_feed(mocker):
         for _ in range(2):
             check_feed.main()
     
+    # Note that the numbers shown for books built are incongruous because
+    # the number is based on the book feed input
+    # In the first test, the feed has 2 books to build
+    # In the second test, the feed has 1 book to build
+    # So the number is actually the count of books on the ABL that are complete
     assert [call.args for call in mock_send_slack_message.call_args_list] == [
         (
             'WebHosting Pipeline Status Update\n'
@@ -1462,7 +1468,9 @@ def test_check_feed(mocker):
             'Version: 20210101.00000001\n'
             'Build Status: Complete ✅\n'
             'Completion Time: 1970-01-01T00:00:00+00:00\n'
-            'Total Books Built: 2',
+            'Books Built: 2\n'
+            'Total Books: 2\n'
+            'Failed Builds: 0',
         ),
         (
             'WebHosting Pipeline Status Update\n'
@@ -1478,7 +1486,9 @@ def test_check_feed(mocker):
             'Version: 20210101.00000001\n'
             'Build Status: Complete ✅\n'
             'Completion Time: 1970-01-01T00:00:00+00:00\n'
-            'Total Books Built: 1',
+            'Books Built: 1\n'
+            'Total Books: 1\n'
+            'Failed Builds: 0',
         ),
     ]
     

--- a/build-concourse/build-webhosting-local.ts
+++ b/build-concourse/build-webhosting-local.ts
@@ -1,5 +1,6 @@
 import { randId, RANDOM_DEV_CODEVERSION_PREFIX } from './util'
 import { loadSaveAndDump} from './build-webhosting'
 
+/* istanbul ignore next (branch coverage) */
 process.env['CODE_VERSION'] = process.env['CODE_VERSION'] ?? `${RANDOM_DEV_CODEVERSION_PREFIX}-${randId}`
 loadSaveAndDump('./env/webhosting-local.json', './webhosting-local.yml')

--- a/build-concourse/env/webhosting-production.json
+++ b/build-concourse/env/webhosting-production.json
@@ -8,7 +8,7 @@
     "WEB_S3_BUCKET": "openstax-web-hosting-content-gatekeeper",
     "WEB_QUEUE_STATE_S3_BUCKET": "openstax-web-hosting-content-queue-state",
     "PREVIEW_APP_URL_PREFIX": "apps/archive",
-    "PIPELINE_TICK_INTERVAL": "12h",
+    "PIPELINE_TICK_INTERVAL": "4h",
     "MAX_BOOKS_PER_TICK": "50",
     "GH_SECRET_CREDS": "git:((github-api-token))",
     "STATE_PREFIX": "git-dist",

--- a/build-concourse/env/webhosting-production.json
+++ b/build-concourse/env/webhosting-production.json
@@ -12,5 +12,7 @@
     "MAX_BOOKS_PER_TICK": "50",
     "GH_SECRET_CREDS": "git:((github-api-token))",
     "STATE_PREFIX": "git-dist",
-    "QUEUE_SUFFIX": "web-hosting-git-queue.json"
+    "QUEUE_SUFFIX": "web-hosting-git-queue.json",
+    "SLACK_WEBHOOK_CE_STREAM": "((slack-webhook-cestream))",
+    "SLACK_WEBHOOK_UNIFIED": "((slack-webhook-unified))"
 }

--- a/build-concourse/env/webhosting-sandbox.json
+++ b/build-concourse/env/webhosting-sandbox.json
@@ -12,5 +12,6 @@
     "MAX_BOOKS_PER_TICK": "50",
     "GH_SECRET_CREDS": "git:((github-api-token))",
     "STATE_PREFIX": "git-dist",
-    "QUEUE_SUFFIX": "web-hosting-git-queue.json"
+    "QUEUE_SUFFIX": "web-hosting-git-queue.json",
+    "SLACK_WEBHOOK_CE_STREAM": "((slack-webhook-cestream))"
 }

--- a/build-concourse/package.json
+++ b/build-concourse/package.json
@@ -6,7 +6,7 @@
     "build:corgi:and-local": "ts-node ./build-corgi-local.ts",
     "build:webhosting": "ts-node ./build-webhosting.ts",
     "build:webhosting:and-local": "ts-node ./build-webhosting-local.ts",
-    "build": "npm run build:json && npm run build:graphs && npm run build:corgi && npm run build:webhosting",
+    "build": "npm run build:json && npm run build:graphs && npm run build:corgi && npm run build:webhosting:and-local",
     "build:local": "npm run build:json && npm run build:corgi:and-local && npm run build:webhosting:and-local",
     "set:webhosting": "npm run build:webhosting && ts-node ./set-webhosting.ts",
     "start": "npm run build",

--- a/build-concourse/script/check_feed.sh
+++ b/build-concourse/script/check_feed.sh
@@ -1,3 +1,13 @@
+SLACK_WEBHOOKS="$( \
+    {
+        echo "${SLACK_WEBHOOK_CE_STREAM:-}"
+        echo "${SLACK_WEBHOOK_UNIFIED:-}"
+    } | \
+    jq -R 'select(length > 0)' | \
+    jq -rs 'join(",")' \
+)"
+export SLACK_WEBHOOKS
+
 check-feed \
 "$CORGI_API_URL" \
 "$CODE_VERSION" \

--- a/build-concourse/step-definitions.ts
+++ b/build-concourse/step-definitions.ts
@@ -10,11 +10,12 @@ export type Step = {
 export const STEP_MAP = new Map<string, Step>()
 
 function get(stepName: string) {
+    const step = STEP_MAP.get(stepName)
     /* istanbul ignore if */
-    if (!STEP_MAP.has(stepName)) {
+    if (!step) {
         throw new Error(`BUG: Missing step named '${stepName}'`)
     }
-    return STEP_MAP.get(stepName)
+    return step
 }
 
 function set(step: Step) {

--- a/build-concourse/util.ts
+++ b/build-concourse/util.ts
@@ -81,6 +81,9 @@ export enum RESOURCES {
     CORGI_GIT_PPTX = 'corgi-git-pptx',
     SLACK_CE_STREAM = 'slack-notifier-ce-stream'
 }
+export enum RESOURCE_TYPES {
+    SLACK_NOTIFY = 'slack-notifier'
+}
 // Note: toConcourseTask converts these into IO_BOOK-style environment variables for the tasks to use
 // so that the scripts do not have to hardcode these directories into the script file
 export enum IO {

--- a/build-concourse/util.ts
+++ b/build-concourse/util.ts
@@ -78,7 +78,8 @@ export enum RESOURCES {
     CORGI_GIT_WEB = 'corgi-git-dist-preview',
     CORGI_GIT_DOCX = 'corgi-git-docx',
     CORGI_GIT_EPUB = 'corgi-git-epub',
-    CORGI_GIT_PPTX = 'corgi-git-pptx'
+    CORGI_GIT_PPTX = 'corgi-git-pptx',
+    SLACK_CE_STREAM = 'slack-notifier-ce-stream'
 }
 // Note: toConcourseTask converts these into IO_BOOK-style environment variables for the tasks to use
 // so that the scripts do not have to hardcode these directories into the script file
@@ -187,6 +188,20 @@ export const reportToCorgi = (resource: RESOURCES) => {
                 ...extras
             }
         }
+    }
+}
+
+export type SlackNotifyOptions = {
+    alert_type?: 'default' | 'success' | 'failed' | 'started' | 'aborted'
+    channel?: string
+    message?: string
+    text?: string
+    color?: string
+}
+
+export const reportToSlack = (resource: RESOURCES) => {
+    return (params: SlackNotifyOptions) => {
+        return { put: resource, params }
     }
 }
 
@@ -340,4 +355,6 @@ export type KeyValue = {
     AWS_SESSION_TOKEN?: string
     QUEUE_SUFFIX: string
     STATE_PREFIX: string
+    SLACK_WEBHOOK_CE_STREAM: string
+    SLACK_WEBHOOK_UNIFIED: string
 }

--- a/cli.env
+++ b/cli.env
@@ -6,8 +6,6 @@ LOCAL_ATTIC_DIR=_attic
 LOCAL_SIDELOAD_REPO_PATH=/sideload-book
 INPUT_SOURCE_DIR=_book-input
 
-ABL_FILE_URL=https://raw.githubusercontent.com/openstax/content-manager-approved-books/adfb6cea998084a8de6d76f768b41f496462d8e8/approved-book-list.json
-
 IO_BOOK=/tmp/build/0000000/book
 
 IO_INITIAL_RESOURCES=/tmp/build/0000000/initial-resources

--- a/step-config.json
+++ b/step-config.json
@@ -225,7 +225,8 @@
             ],
             "requiredEnv": [
                 "S3_QUEUE",
-                "CODE_VERSION"
+                "CODE_VERSION",
+                "QUEUE_SUFFIX"
             ]
         },
         "git-report-book-complete": {
@@ -237,7 +238,8 @@
                 "CODE_VERSION",
                 "WEB_QUEUE_STATE_S3_BUCKET",
                 "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY"
+                "AWS_SECRET_ACCESS_KEY",
+                "STATE_PREFIX"
             ]
         }
     },

--- a/test/test-step-10.bash
+++ b/test/test-step-10.bash
@@ -12,7 +12,7 @@ fi
 # More details: https://github.com/aws/aws-cli/issues/8036#issuecomment-1638544754
 # and: https://github.com/yaml/pyyaml/issues/601
 # PyYAML installed as dependency here [awscli](https://github.com/aws/aws-cli/blob/dbbf1ce01acec0116710968bbe5a96680e791c1b/setup.py#L30)
-pip install "PyYAML==5.3.1" "../bakery-src/scripts/.[test]"
+pip install "../bakery-src/scripts/.[test]"
 flake8 "../bakery-src/scripts" --max-line-length=110
 
 pytest --asyncio-mode=strict --cov=bakery_scripts --cov-append --cov-report=xml:cov.xml --cov-report=html:cov.html --cov-report=term-missing  ../bakery-src -vvv


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1006

- [x] Test pipelines should not send notifications (they use the staging pipeline configuration)
- [x] Sends notification to ce-stream webhook (if provided)
- [x] Sends notification to unified webhook (if provided)
- [x] Includes information about code version, books built, failed build count, etc. (see tests for example messages)
- [x] Only notifies once until "revival" (revival meaning that it finds new books to build)
- [x] After "revival" it will notify again
- [x] Failure to notify should not interfere with normal operations
- [x] Notifies on build failure using `arbourd/concourse-slack-alert-resource` (notifications sent to ce-stream only)

I also added support for using `chat.postMessage`. I figured it was not much extra work and might be useful in the future.

Sorry about the extra stuff. These were some small changes I had in my working tree that were going to be needed eventually, but didn't really fit into other stuff.

* The PyYAML version thing was a temporary workaround that was no longer needed.
* The step config is something that should have been committed with the change that caused it to change.
* The xml annotation thing was a problem that came up during algebra-1 development. Since it's only annotating, I don't think the entire build should fail if it runs into problems. Plus, there is better error handling in other parts of the pipeline.