### PR TITLE
CORE-845 - Link iframes in postbake

### DIFF
--- a/bakery-src/scripts/link_single.py
+++ b/bakery-src/scripts/link_single.py
@@ -121,9 +121,10 @@ def gen_composite_page_slug_resolver(binders_by_book_uuid, page_slug_resolver):
 
                 model_id, content = model.id, model.content
                 if encoded_page_id in content:
-                    parsed = parsed_by_id.setdefault(
-                        model_id, etree.fromstring(content)
-                    )
+                    parsed = parsed_by_id.get(model_id, None)
+                    if parsed is None:
+                        parsed = etree.fromstring(content)
+                        parsed_by_id[model_id] = parsed
                     id_search = parsed.xpath(
                         './/*[@data-type="composite-page"]/@id'
                     )
@@ -139,7 +140,7 @@ def gen_composite_page_slug_resolver(binders_by_book_uuid, page_slug_resolver):
         if not composite_page_uuid:
             return None
         return page_slug_resolver(book_uuid, composite_page_uuid)
-    
+
     return _get_composite_page_slug
 
 

--- a/bakery-src/tests/test_bakery_scripts.py
+++ b/bakery-src/tests/test_bakery_scripts.py
@@ -2859,6 +2859,10 @@ def test_link_single(tmp_path, mocker):
         <a href="">
         </a>
         </li>
+        <li cnx-archive-uri="composite-page-3">
+        <a href="">
+        </a>
+        </li>
         </ol>
         </nav>
         <div>
@@ -2912,6 +2916,24 @@ def test_link_single(tmp_path, mocker):
             </h1>
             <div data-type="metadata" style="display: none;">
                 <h1 data-type="document-title" itemprop="name">Index</h1>
+                <span data-type="revised" data-value="2025-05-21T14:35:53+00:00"/><span data-type="slug" data-value="algebra-1"/><div class="permissions">
+                    <p class="license">
+                    Licensed:
+                    <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license" target="_blank" rel="noopener nofollow">Creative Commons Attribution-NonCommercial-ShareAlike License</a>
+                    </p>
+                </div>
+            </div>
+            <div class="os-has-iframe os-has-link" data-type="switch">
+                <a class="os-is-link" href="/404" data-check-rex-link="true" data-needs-rex-link="true" target="_blank" rel="noopener nofollow" data-media="print">Access multimedia content</a>
+                <iframe width="660" height="371.4" src="https://edge-case-shared-composite-page-uuid.com" data-sm="./modules/m00033/index.cnxml:13:9" class="os-is-iframe" data-media="screen"><!-- no-selfclose --></iframe>
+            </div>
+        </div>
+        <div class="os-eob os-index-container" data-type="composite-page" data-uuid-key="not-index" id="composite-page-3" data-book-content="true">
+            <h1 data-type="document-title">
+                <span class="os-text">Not Index</span>
+            </h1>
+            <div data-type="metadata" style="display: none;">
+                <h1 data-type="document-title" itemprop="name">Not Index</h1>
                 <span data-type="revised" data-value="2025-05-21T14:35:53+00:00"/><span data-type="slug" data-value="algebra-1"/><div class="permissions">
                     <p class="license">
                     Licensed:
@@ -3093,6 +3115,17 @@ def test_link_single(tmp_path, mocker):
         [
             ('class', 'os-is-link'),
             ('href', 'http://openstax.org/books/book1/pages/index'),
+            ('data-check-rex-link', 'true'),
+            ('target', '_blank'),
+            ('rel', 'noopener nofollow'),
+            ('data-media', 'print'),
+            ('text', 'Access multimedia content'),
+        ],
+        [
+            # This edge case occurs when two composite pages have the same
+            # uuid-key. In such a case, they have the same uuid (RIP)
+            ('class', 'os-is-link'),
+            ('href', 'https://edge-case-shared-composite-page-uuid.com'),
             ('data-check-rex-link', 'true'),
             ('target', '_blank'),
             ('rel', 'noopener nofollow'),


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-845

Attempt 2: This time it should support composite pages properly.

It's meant to replace this function from cookbook:

```ruby
    def rex_link
      self[:'data-is-for-rex-linking'] = 'true'

      element_with_ancestors = document.book.chapters.search_with(
        Kitchen::PageElementEnumerator, Kitchen::CompositePageElementEnumerator
      ).search('[data-is-for-rex-linking="true"]').first

      remove_attribute('data-is-for-rex-linking')

      unless element_with_ancestors
        raise("Cannot create rex link to element #{self} - needs ancestors of both types chapter & page/composite_page" \
              "#{say_source_or_nil}"
        )
      end

      book_slug = document.slug
      chapter_count = element_with_ancestors.ancestor(:chapter).count_in(:book)
      page_string = ''
      page_title = ''
      page = element_with_ancestors.ancestor(:page) if element_with_ancestors.has_ancestor?(:page)
      if page&.is_introduction?
        page_title = page.first('[data-type="document-title"]').text.slugify
      elsif page
        page_string = "#{page.count_in(:chapter) - 1}-"
        page_title = page.title_text.slugify
      else
        page = element_with_ancestors.ancestor(:composite_page)
        page_title = page.title.text.slugify
      end

      "https://openstax.org/books/#{book_slug}/pages/#{chapter_count}-#{page_string}#{page_title}"
    end
```

## What I accounted for:
- [x] Introduction pages do not need a special case in my version because they are just pages with static ids like any other
- [x] Chapter and page count are already included in the page slug
- [x] Composite pages have slugs like normal pages, but their id works a little differently
- [x] Composite page ids should be unique within a book: see [here](https://github.com/openstax/cookbook/blob/6c1c8b443be65f86d2655ec2d564b6e9e6ec302d/lib/kitchen/directions/bake_composite_pages.rb#L8) for more info.

## Composite Page Slug Resolver Explained
- The existing metadata document includes page slugs for normal pages and composite pages
- Composite pages do not have a static id like normal pages. Their id is generated [here](https://github.com/openstax/enki/blob/4d440d838a270ccafd2d9054860e854cabcd4181/bakery-src/scripts/html_parser.py#L236-L256).
- We can map the generated id back to the id in the document.
- The resolver searches the associated binder for a matching composite page id and then returns the model uuid (generated id).
  - For added speed, it uses an `in` check before parsing the document and ensure the id matches as expected
  - Includes some caching of parsed content (probably not needed, honestly).
- Next the resolver uses the existing page slug resolver to resolve the composite page uuid to a page slug.

## Added Structural Dependence (Negative)

I am using the book document structure to get the canonical book uuid as opposed to using `canonical_map`. It would be possible to use `canonical_map` by using the id of the first page. This would probably be less readable and it would still be assuming that all pages are in the same book so it doesn't really eliminate the structural dependence completely. 

At the moment, I believe `canonical_map` only contains normal documents/pages, not composite documents/pages. 

## Other Stuff

You might wonder: if you can reliably get the id of a composite page based on the book id and element id, then why not use those to create the uuid instead of the parent id + uuid-key? I think that would work, but a change like that would probably break a bunch of stuff because all the composite ids would suddenly change. In fact, this approach would possibly fix an edge case I uncovered while working on this. If there are two composite pages with the same uuid-key at the top level of the document, they will both have the same uuid 💥

One thing to remember, however, is that composite page ids could change between book builds if new composite pages are added. That might be why the edge case exists: to avoid using composite page ids when generating the uuid.