### PR TITLE
Filter repo slugs by selected books

### DIFF
--- a/dockerfiles/steps/step-upload-book.bash
+++ b/dockerfiles/steps/step-upload-book.bash
@@ -70,7 +70,7 @@ if [[ $ARG_ENABLE_CORGI_UPLOAD == 1 ]]; then
         rex_prod_url="$REX_PROD_PREVIEW_URL/apps/rex/books/$book_uuid@$book_version/pages/$first_page_slug$rex_archive_param"
 
         book_slug_urls+=("$(jo url="$rex_prod_url" slug="$book_slug")")
-    done < <(read_book_slugs --from-repo)  # LCOV_EXCL_LINE
+    done < <(read_book_slugs --from-repo | grep -Fxf <(read_book_slugs))  # LCOV_EXCL_LINE
 
     while IFS='|' read -r url slug; do
         book_slug_urls+=("$(jo url="$url" slug="$slug")")

--- a/test/test-step-03.bash
+++ b/test/test-step-03.bash
@@ -86,6 +86,11 @@ EOF
 # when books.xml contains additional non-super books that were not selected.
 books_xml="$(find "$BOOK_DIR" -path "*/IO_FETCH_META/META-INF/books.xml")"
 cp "$books_xml" "$books_xml.bak"
+cleanup_books_xml() {
+    [[ -f "$books_xml.bak" ]] && mv -f "$books_xml.bak" "$books_xml"
+    rm -f "$BOOK_DIR/_attic/IO_ARTIFACTS/book-slug2.toc.json"
+}
+trap cleanup_books_xml EXIT
 cat > "$books_xml" <<'EOF'
 <container xmlns="https://openstax.org/namespaces/book-container" version="1">
     <book slug="book-slug1" style="dummy" href="../collections/book-slug1.collection.xml"/>

--- a/test/test-step-03.bash
+++ b/test/test-step-03.bash
@@ -82,6 +82,43 @@ done <<EOF
 ancillary
 EOF
 
+# Regression test: only CORGI-selected slugs should appear in artifact_urls.json
+# when books.xml contains additional non-super books that were not selected.
+books_xml="$(find "$BOOK_DIR" -path "*/IO_FETCH_META/META-INF/books.xml")"
+cp "$books_xml" "$books_xml.bak"
+cat > "$books_xml" <<'EOF'
+<container xmlns="https://openstax.org/namespaces/book-container" version="1">
+    <book slug="book-slug1" style="dummy" href="../collections/book-slug1.collection.xml"/>
+    <book slug="book-slug2" style="dummy" href="../collections/book-slug2.collection.xml"/>
+</container>
+EOF
+cat > "$BOOK_DIR/_attic/IO_ARTIFACTS/book-slug2.toc.json" <<'EOF'
+{"title":"test book 2","tree":{"id":"99999999-9999-9999-9999-999999999999@03e68a5","title":"test book 2","contents":[{"id":"22222222-2222-4222-8222-222222222222@","title":"Introduction","slug":"introduction"}],"slug":"test-book-2"},"slug":"book-slug2","id":"99999999-9999-9999-9999-999999999999","version":"03e68a5"}
+EOF
+echo -n "book-slug1" > "$(find "$BOOK_DIR" -type d -name "IO_BOOK")/slugs"
+
+SKIP_DOCKER_BUILD=1 \
+STUB_UPLOAD="corgi" \
+../enki --keep-data --data-dir $BOOK_DIR --command step-upload-book --repo 'philschatz/tiny-book' --ref '03e68a5f78e8fb2ceab04aa719a6daf30a7999b0'
+
+if grep -q "book-slug2" "$ARTIFACTS_URL_PATH"; then
+    echo "Non-selected book slug book-slug2 should not appear in artifact_urls.json"
+    echo "Actual: $(cat "$ARTIFACTS_URL_PATH")"
+    mv "$books_xml.bak" "$books_xml"
+    rm -f "$BOOK_DIR/_attic/IO_ARTIFACTS/book-slug2.toc.json"
+    exit 1
+fi
+if ! grep -q "book-slug1" "$ARTIFACTS_URL_PATH"; then
+    echo "Selected book slug book-slug1 should appear in artifact_urls.json"
+    echo "Actual: $(cat "$ARTIFACTS_URL_PATH")"
+    mv "$books_xml.bak" "$books_xml"
+    rm -f "$BOOK_DIR/_attic/IO_ARTIFACTS/book-slug2.toc.json"
+    exit 1
+fi
+
+mv "$books_xml.bak" "$books_xml"
+rm -f "$BOOK_DIR/_attic/IO_ARTIFACTS/book-slug2.toc.json"
+
 # Test without book slug
 rm $BOOK_DIR/_attic/IO_BOOK/slugs
 SKIP_DOCKER_BUILD=1 \


### PR DESCRIPTION
🤦 Oops

Context:
> I started reading slugs from the repository during upload, ignoring the books you select in CORGI. Then we get extra books that are seen as “ephemeral” books and they are attached to the commit. Then those stick around and appear as extra books in the job dialog. 